### PR TITLE
Provide SiteSearchInput with genomics-site-specific placeholderText

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/component-wrappers/SiteSearchInput.tsx
+++ b/Site/webapp/wdkCustomization/js/client/component-wrappers/SiteSearchInput.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import { useWdkService } from 'wdk-client/Hooks/WdkServiceHook';
+import { DatasetParam } from 'wdk-client/Utils/WdkModel';
+
+import { Props } from 'ebrc-client/components/SiteSearch/SiteSearchInput';
+
+export function SiteSearchInput(DefaultComponent: React.ComponentType<Props>) {
+  return function() {
+    const placeholderText = useWdkService(async wdkService => {
+      const [ idSearch, textSearch ] = await Promise.all([
+        wdkService.getQuestionAndParameters('GeneByLocusTag').catch(),
+        wdkService.getQuestionAndParameters('GenesByText').catch()
+      ]);
+      const id = idSearch?.parameters.find((p): p is DatasetParam => p.name === 'ds_gene_ids')?.defaultIdList;
+      const text = textSearch?.parameters.find(p => p.name === 'text_expression')?.initialDisplayValue;
+      const examples = [ id, text, `"binding protein"` ].filter(v => v).join(' or ');
+      return 'Site search, e.g. ' + examples;
+    }, []);
+
+    return <DefaultComponent placeholderText={placeholderText} />;
+  }
+}

--- a/Site/webapp/wdkCustomization/js/client/componentWrappers.jsx
+++ b/Site/webapp/wdkCustomization/js/client/componentWrappers.jsx
@@ -28,6 +28,8 @@ import { apiActions } from './components/strategies/ApiStepDetailsActions';
 
 import { VEuPathDBHomePage } from './components/homepage/VEuPathDBHomePage';
 
+import { SiteSearchInput as SiteSearchInputWrapper } from './component-wrappers/SiteSearchInput';
+
 export const SiteHeader = () => ApiSiteHeader;
 
 const stopPropagation = event => event.stopPropagation();
@@ -396,3 +398,5 @@ export function Page() {
     return <VEuPathDBHomePage {...props} isHomePage={isHomePage} />;
   };
 }
+
+export const SiteSearchInput = SiteSearchInputWrapper;


### PR DESCRIPTION
This PR moves the logic for deriving the genomics site search placeholderText from EbrcWebsiteCommon to ApiCommonWebsite. This is needed as part of fixing a ServiceError that is thrown in the OrthoMCL client (see https://github.com/VEuPathDB/EbrcWebsiteCommon/pull/5 for more details).

Depends on https://github.com/VEuPathDB/EbrcWebsiteCommon/pull/5