### PR TITLE
Reintroduce "beta" superscript into page header for build 48 release

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.scss
+++ b/Site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.scss
@@ -43,14 +43,15 @@
         @if ($superscript-position-top) {
           top: $superscript-position-top;
         } @else {
-          top: 0.5em;
+          top: 0.8em;
         }
         left: $superscript-position-left;
         @if ($superscript-font-size) {
           font-size: $superscript-font-size;
         } @else {
-          font-size: 1em;
+          font-size: 1.4em;
         }
+        font-style: italic;
         font-weight: 500;
         color: white;
         white-space: nowrap;

--- a/Site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
@@ -163,9 +163,7 @@ const VEuPathDBHomePageView: FunctionComponent<Props> = props => {
         </div>
       </Link>
       <div className={vpdbCx('HeaderBrandingSuperscript')}>
-        {props.buildNumber && `Release ${props.buildNumber}`}
-        <br />
-        {props.releaseDate && formatReleaseDate(props.releaseDate)}
+        beta
       </div>
     </>
   );


### PR DESCRIPTION
In UX, it was decided that we would continue to display the "beta" superscript on our build 48 genomics sites.

Codependent on https://github.com/VEuPathDB/EbrcWebsiteCommon/pull/9