### PR TITLE
Organism Filter: only display Summary Field Requests for the current step

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/components/OrganismFilter.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/OrganismFilter.tsx
@@ -101,15 +101,20 @@ function Container(props: ContainerProps) {
   )
 }
 
-function OrganismFilter({resultType, requestUpdateStepSearchConfig}: Props) {
+function OrganismFilter({ resultType, ...otherProps}: Props) {
+  const step = resultType.type === 'step' ? resultType.step : undefined;
 
-  const step = resultType && resultType.type === 'step' && resultType.step;
-
-  // don't show anything until step loaded, and after that only if a transcript step
-  if (!step || step.recordClassName !== ALLOWABLE_RECORD_CLASS_NAME) {
+  // only show Organism Filter for transcript step results
+  if (step == null || step.recordClassName !== ALLOWABLE_RECORD_CLASS_NAME) {
     return null;
   }
 
+  return <OrganismFilterForStep step={step} {...otherProps} />;
+}
+
+type OrganismFilterForStepProps = { step: Step } & Omit<Props, 'resultType'>;
+
+function OrganismFilterForStep({step, requestUpdateStepSearchConfig}: OrganismFilterForStepProps) {
   // if temporary value assigned, use until user clears or hits apply;
   // else check step for a filter value and if present, use; else use empty string (no filter)
   let appliedFilterConfig: OrgFilterConfig = findOrganismFilterConfig(step.searchConfig);

--- a/Site/webapp/wdkCustomization/js/client/components/OrganismFilter.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/OrganismFilter.tsx
@@ -8,7 +8,7 @@ import { Step } from 'wdk-client/Utils/WdkUser';
 import { requestUpdateStepSearchConfig } from 'wdk-client/Actions/StrategyActions';
 import { Loading, CheckboxTree } from 'wdk-client/Components';
 import { mapStructure } from 'wdk-client/Utils/TreeUtils';
-import {ResultType} from 'wdk-client/Utils/WdkResult';
+import { ResultType } from 'wdk-client/Utils/WdkResult';
 import {makeClassNameHelper} from 'wdk-client/Utils/ComponentUtils';
 import { areTermsInString, makeSearchHelpText } from 'wdk-client/Utils/SearchUtils';
 import { useWdkServiceWithRefresh } from 'wdk-client/Hooks/WdkServiceHook';
@@ -101,8 +101,8 @@ function Container(props: ContainerProps) {
   )
 }
 
-function OrganismFilter({ resultType, ...otherProps}: Props) {
   const step = resultType.type === 'step' ? resultType.step : undefined;
+function OrganismFilter({ resultType, ...otherProps }: Props) {
 
   // only show Organism Filter for transcript step results
   if (step == null || step.recordClassName !== ALLOWABLE_RECORD_CLASS_NAME) {
@@ -114,7 +114,7 @@ function OrganismFilter({ resultType, ...otherProps}: Props) {
 
 type OrganismFilterForStepProps = { step: Step } & Omit<Props, 'resultType'>;
 
-function OrganismFilterForStep({step, requestUpdateStepSearchConfig}: OrganismFilterForStepProps) {
+function OrganismFilterForStep({ step, requestUpdateStepSearchConfig }: OrganismFilterForStepProps) {
   // if temporary value assigned, use until user clears or hits apply;
   // else check step for a filter value and if present, use; else use empty string (no filter)
   let appliedFilterConfig: OrgFilterConfig = findOrganismFilterConfig(step.searchConfig);

--- a/Site/webapp/wdkCustomization/js/client/components/OrganismFilter.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/OrganismFilter.tsx
@@ -101,8 +101,8 @@ function Container(props: ContainerProps) {
   )
 }
 
-  const step = resultType.type === 'step' ? resultType.step : undefined;
 function OrganismFilter({ resultType, ...otherProps }: Props) {
+  const step = resultType?.type === 'step' ? resultType.step : undefined;
 
   // only show Organism Filter for transcript step results
   if (step == null || step.recordClassName !== ALLOWABLE_RECORD_CLASS_NAME) {


### PR DESCRIPTION
This PR addresses a bug where we were rendering organism counts for steps other than the one we have selected. The solution is to "cancel" / "ignore" the filter summary request if we navigate to a new step before said request is fulfilled.

In addition, we fix a subtle violation of the rules of hooks (an early return from the `OrganismFilter` component when the result isn't a transcript step).

Depends on https://github.com/VEuPathDB/WDKClient/pull/60.