### PR TITLE
Two related bugfixes for the JBrowse scroll lock

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/components/common/Gbrowse.jsx
+++ b/Site/webapp/wdkCustomization/js/client/components/common/Gbrowse.jsx
@@ -5,6 +5,8 @@ import { httpGet } from 'ebrc-client/util/http';
 import $ from 'jquery';
 import { Checkbox, HelpIcon, Loading } from 'wdk-client/Components';
 
+import './Gbrowse.scss';
+
 const SCROLL_AND_ZOOM_CHECKBOX_TOOLTIP_POSITION = {
   my: 'bottom right',
   at: 'top center'
@@ -132,7 +134,7 @@ function JbrowseIframe({ jbrowseUrl,ht }) {
 
   const jbrowseViewContainer = useRef(null);
   const lockText = (
-    <small>
+    <small className="jbrowse-scroll-zoom-toggle-caption">
       Scroll and zoom
       {' '}
       <HelpIcon
@@ -175,13 +177,12 @@ function JbrowseIframe({ jbrowseUrl,ht }) {
           marginBottom: '0.5em'
         }}
       >
-        <Checkbox
-          id="jbrowse-scroll-zoom-toggle"
-          style={{ marginRight: '0.25em' }}
-          value={!isLocked}
-          onChange={onCheckboxToggle}
-        />
-        <label htmlFor="jbrowse-scroll-zoom-toggle">
+        <label className="jbrowse-scroll-zoom-toggle">
+          <Checkbox
+            style={{ marginRight: '0.25em' }}
+            value={!isLocked}
+            onChange={onCheckboxToggle}
+          />
           {lockText}
         </label>
       </div>

--- a/Site/webapp/wdkCustomization/js/client/components/common/Gbrowse.scss
+++ b/Site/webapp/wdkCustomization/js/client/components/common/Gbrowse.scss
@@ -1,7 +1,7 @@
 .jbrowse-scroll-zoom-toggle {
   &-caption {
     .HelpTrigger {
-      position: unset;
+      position: static;
     }
   }
 }

--- a/Site/webapp/wdkCustomization/js/client/components/common/Gbrowse.scss
+++ b/Site/webapp/wdkCustomization/js/client/components/common/Gbrowse.scss
@@ -1,0 +1,7 @@
+.jbrowse-scroll-zoom-toggle {
+  &-caption {
+    .HelpTrigger {
+      position: unset;
+    }
+  }
+}


### PR DESCRIPTION
This PR fixes two bugs pertaining to the JBrowse scroll lock:

1. To address an aggressively-applied style for help icons which lie inside a `.wdk-DataTable`s (located [here](https://github.com/VEuPathDB/WDKClient/blob/master/Client/src/Components/DataTable/DataTable.css)), we provide a higher-specificity style for the scroll toggle's help icon.
2. The label for the scroll toggle checkbox is now assigned implicitly. This addressed a bug where clicking on the label of the second/third/n-th scroll toggle label was toggling the checkbox of the FIRST scroll toggle.