### PR TITLE
Internal Gene Dataset routing fix

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.scss
+++ b/Site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.scss
@@ -107,12 +107,16 @@
     -ms-filter: "progid:DXImageTransform.Microsoft.Gradient(startColorStr=#5bc0de, endColorStr=#2f96b4)";
   }
 
-  .bttn:active, .bttn-active {
+  .bttn:active, .bttn-active, .bttn-legend {
     background-image: none;
     box-shadow: 1px 1px 0 #dddddd;
     -moz-box-shadow: 1px 1px 0 #dddddd;
     -webkit-box-shadow: 1px 1px 0 #dddddd;
     -ms-filter: "progid:DXImageTransform.Microsoft.Shadow(Strength=1, Direction=135, Color='#eeeeee')";
+  }
+
+  .bttn:active, .bttn.bttn-active {
+    cursor: default;
   }
 
   &NewDataset {

--- a/Site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
@@ -304,7 +304,7 @@ export function InternalGeneDataset(props: Props) {
                         }
                       >
                         <span key={categoryName}>
-                          <span className="bttn bttn-cyan bttn-active">
+                          <span className="bttn bttn-cyan bttn-legend">
                             {displayCategoriesByName[categoryName].shortDisplayName}
                           </span>
                           <span>

--- a/Site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
@@ -68,6 +68,10 @@ export function InternalGeneDataset(props: Props) {
 
   const [ selectedSearch, setSelectedSearch ] = useState<string | undefined>(searchNameAnchorTag);
 
+  useEffect(() => {
+    setSelectedSearch(searchNameAnchorTag);
+  }, [ searchNameAnchorTag ]);
+
   const [ searchName, showingRecordToggle ] = selectedSearch
     ? [ selectedSearch, true ]
     : [ internalSearchName, false ];


### PR DESCRIPTION
This PR addresses a [recently observed bug re: routing on Internal Gene Dataset custom question pages](https://redmine.apidb.org/issues/41325). The fix is to update `selectedSearch` whenever the search page URL's hash changes.

In addition, some peripheral cleanup is undertaken:

1. Some duplicate logic is factored out into helper functions.
2. The interface for the controller's props is now precisely the `Props` for the default `QuestionController`; this reduces the risk of bugs whenever a new `QuestionController` prop is introduced/removed/changed. As a corollary, Internal Gene Dataset *search* pages now `prepopulateWithLastParamValues`.
3. The `connect`ion with the Redux store is phased out in favor of `useSelector`. (In the not-so-long term, we could instead `useWdkService` to retrieve the necessary global data.)