### PR TITLE
Pathways Graph UX feedback

### DIFF
--- a/Site/webapp/wdkCustomization/css/pathway.css
+++ b/Site/webapp/wdkCustomization/css/pathway.css
@@ -145,6 +145,8 @@
 }
 
 .veupathdb-PathwaySearchById {
+  display: flex;
+  align-items: center;
   width: 100%;
   padding: 0.5em 3em;
 }

--- a/Site/webapp/wdkCustomization/js/client/components/records/PathwayRecordClasses.PathwayRecordClass.jsx
+++ b/Site/webapp/wdkCustomization/js/client/components/records/PathwayRecordClasses.PathwayRecordClass.jsx
@@ -43,6 +43,8 @@ const ORTHOMCL_LINK = 'https://beta.orthomcl.org/orthomcl/processQuestion.do?que
 const clearFoundNodes = clearHighlighting('veupathdb-CytoscapeFoundNode');
 const highlightFoundNodes = highlightNodes('veupathdb-CytoscapeFoundNode');
 
+const FOUND_NODE_HIGHLIGHTING_COLOR = '#009E73';
+
 function loadCytoscapeJs() {
   return new Promise(function(resolve, reject) {
     try {
@@ -678,7 +680,7 @@ function makeCy(container, pathwayId, pathwaySource, PathwayNodes, PathwayEdges,
             {
               selector: 'node.veupathdb-CytoscapeFoundNode',
               style: {
-                'border-color': 'green',
+                'border-color': FOUND_NODE_HIGHLIGHTING_COLOR,
                 'border-width': '4px'
               },
             },
@@ -1326,6 +1328,20 @@ const CytoscapeDrawing = enhance(class CytoscapeDrawing extends React.Component 
             <PathwaySearchById
               onSearchCriteriaChange={this.onSearchCriteriaChange}
               cy={this.state.cy}
+              helpText={
+                <span>
+                  <ul>
+                    <li>
+                      Node names and identifiers will be searched
+                    </li>
+                    <li>
+                      Nodes which match your search criteria will be highlighted with
+                      {' '}
+                      <span style={{ color: FOUND_NODE_HIGHLIGHTING_COLOR }}>this color</span>
+                    </li>
+                  </ul>
+                </span>
+              }
             />
           )}
           <div className="veupathdb-PathwayRecord-menuControls">

--- a/Site/webapp/wdkCustomization/js/client/components/records/PathwayRecordClasses.PathwayRecordClass.jsx
+++ b/Site/webapp/wdkCustomization/js/client/components/records/PathwayRecordClasses.PathwayRecordClass.jsx
@@ -1325,7 +1325,7 @@ const CytoscapeDrawing = enhance(class CytoscapeDrawing extends React.Component 
           {this.state.cy && (
             <PathwaySearchById
               onSearchCriteriaChange={this.onSearchCriteriaChange}
-              nodes={this.state.cy.nodes()}
+              cy={this.state.cy}
             />
           )}
           <div className="veupathdb-PathwayRecord-menuControls">

--- a/Site/webapp/wdkCustomization/js/client/components/records/PathwaySearchById.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/records/PathwaySearchById.tsx
@@ -3,7 +3,7 @@ import Select from 'react-select';
 import { ActionMeta, InputActionMeta, ValueType } from 'react-select/src/types';
 import { Option } from 'react-select/src/filters';
 
-import { NodeCollection } from 'cytoscape';
+import { Core } from 'cytoscape';
 import { isEqual, orderBy, uniqWith } from 'lodash';
 
 import { safeHtml } from 'wdk-client/Utils/ComponentUtils';
@@ -12,7 +12,7 @@ import { stripHTML } from 'wdk-client/Views/Records/RecordUtils';
 import { NodeSearchCriteria } from './pathway-utils';
 
 interface Props {
-  nodes: NodeCollection;
+  cy: Core;
   onSearchCriteriaChange: (searchCriteria: NodeSearchCriteria | undefined) => void;
 }
 
@@ -21,11 +21,13 @@ interface NodeOptionDatum {
   node_identifier: string | undefined;
 };
 
-export function PathwaySearchById({ nodes, onSearchCriteriaChange }: Props) {
+export function PathwaySearchById({ cy, onSearchCriteriaChange }: Props) {
   const [ searchTerm, setSearchTerm ] = useState('');
 
   const options = useMemo(
     () => {
+      const nodes = cy.nodes();
+
       const identifiableNodes = nodes.toArray().filter(
         node => node.data('node_identifier') != null || node.data('name') != null
       );
@@ -54,7 +56,7 @@ export function PathwaySearchById({ nodes, onSearchCriteriaChange }: Props) {
         nodeOption => nodeOption.label
       );
     },
-    [ nodes ]
+    [ cy ]
   );
 
   const fullOptions = useMemo(
@@ -72,6 +74,11 @@ export function PathwaySearchById({ nodes, onSearchCriteriaChange }: Props) {
   );
 
   const [ selection, setSelection ] = useState([] as Option[]);
+
+  useEffect(() => {
+    setSearchTerm('');
+    setSelection([]);
+  }, [ cy ]);
 
   const onChange = useCallback((newSelection: ValueType<Option>, meta: ActionMeta) => {
     const newSelectionArray = newSelection == null

--- a/Site/webapp/wdkCustomization/js/client/components/records/PathwaySearchById.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/records/PathwaySearchById.tsx
@@ -6,13 +6,20 @@ import { Option } from 'react-select/src/filters';
 import { Core } from 'cytoscape';
 import { isEqual, orderBy, uniqWith } from 'lodash';
 
+import { HelpIcon } from 'wdk-client/Components';
 import { safeHtml } from 'wdk-client/Utils/ComponentUtils';
 import { stripHTML } from 'wdk-client/Views/Records/RecordUtils';
 
 import { NodeSearchCriteria } from './pathway-utils';
 
+const TOOLTIP_POSITION = {
+  my: 'bottom left',
+  at: 'top right'
+};
+
 interface Props {
   cy: Core;
+  helpText?: JSX.Element;
   onSearchCriteriaChange: (searchCriteria: NodeSearchCriteria | undefined) => void;
 }
 
@@ -21,7 +28,11 @@ interface NodeOptionDatum {
   node_identifier: string | undefined;
 };
 
-export function PathwaySearchById({ cy, onSearchCriteriaChange }: Props) {
+export function PathwaySearchById({
+  cy,
+  helpText,
+  onSearchCriteriaChange
+}: Props) {
   const [ searchTerm, setSearchTerm ] = useState('');
 
   const options = useMemo(
@@ -106,7 +117,7 @@ export function PathwaySearchById({ cy, onSearchCriteriaChange }: Props) {
   }, []);
 
   const noOptionsMessage = useCallback(
-    () => 'No identifiers match your search term',
+    () => 'No names or identifiers match your search term',
     []
   );
 
@@ -168,10 +179,18 @@ export function PathwaySearchById({ cy, onSearchCriteriaChange }: Props) {
         styles={{
           container: base => ({
             ...base,
-            zIndex: 99
+            zIndex: 99,
+            flex: 'auto',
+            paddingRight: '0.25em'
           })
         }}
       />
+      {
+        helpText &&
+        <HelpIcon tooltipPosition={TOOLTIP_POSITION}>
+          {helpText}
+        </HelpIcon>
+      }
     </div>
   );
 }


### PR DESCRIPTION
This PR addresses some feedback for the new Pathways Graph UI features:

* Clicking "Reset Layout" now clears the search bar
* The highlighting color for "found nodes" is a now a color blind-friendly green-blue (from the [Okabe-Ito scale](https://wp.nyu.edu/siegal/color-palette/))
* The search bar now has a help icon describing (1) precisely what node data is searched, as well as (2) the significance of the highlighting