### PR TITLE
Fixes for ByLocation and DynSpansBySourceId custom question pages which don't have mutually exclusive params

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/components/questions/ByLocation.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/questions/ByLocation.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useMemo, useState } from 'react';
 
+import { isEnumParam } from 'wdk-client/Views/Question/Params/EnumParamUtils';
 import { useChangeParamValue } from 'wdk-client/Views/Question/Params/Utils';
-import { ParameterGroup, SelectEnumParam, QuestionWithParameters } from 'wdk-client/Utils/WdkModel';
+import { ParameterGroup, QuestionWithParameters } from 'wdk-client/Utils/WdkModel';
 import { Step } from 'wdk-client/Utils/WdkUser';
 import { Props } from 'wdk-client/Views/Question/DefaultQuestionForm';
 import {
@@ -27,7 +28,7 @@ const SEQUENCE_ID_EMPTY = /(\(Example: .*\)|No match)/i;
 
 export function ByLocationForm(props: Props) {
   const chromosomeOptionalKey = findChromosomeOptionalKey(props.state.question.paramNames);
-  const chromosomeOptionalParam = props.state.question.parametersByName[chromosomeOptionalKey] as SelectEnumParam;
+  const chromosomeOptionalParam = props.state.question.parametersByName[chromosomeOptionalKey];
 
   const sequenceIdKey = findSequenceIdKey(props.state.question.paramNames);
 
@@ -58,7 +59,12 @@ export function ByLocationForm(props: Props) {
   );
 
   const clearChromosomeOptional = useCallback(() => {
-    changeChromosomeOptional(chromosomeOptionalParam.vocabulary[0][0]);
+    if (
+      isEnumParam(chromosomeOptionalParam) &&
+      chromosomeOptionalParam.displayType === 'select'
+    ) {
+      changeChromosomeOptional(chromosomeOptionalParam.vocabulary[0][0]);
+    }
   }, [ chromosomeOptionalParam, changeChromosomeOptional ]);
 
   const clearSequenceId = useCallback(() => {
@@ -75,7 +81,7 @@ export function ByLocationForm(props: Props) {
     }
 
     return true;
-  }, [ clearChromosomeOptional, activeTab ]);
+  }, [ clearChromosomeOptional, clearSequenceId, activeTab ]);
 
   return (
     <EbrcDefaultQuestionForm

--- a/Site/webapp/wdkCustomization/js/client/components/questions/MutuallyExclusiveParams/utils.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/questions/MutuallyExclusiveParams/utils.tsx
@@ -71,7 +71,7 @@ const findChromosomeAndSequenceIDXorGroup = findXorGroup(xorGroupingByChromosome
 
 const groupHasParam = (groupParamNames: Set<string>) => (targetParamName: string) => {
   return groupParamNames.has(targetParamName);
-}
+};
 
 export const hasChromosomeAndSequenceIDXorGroup = (question: Question) => {
   const xorGroup = findChromosomeAndSequenceIDXorGroup(question);

--- a/Site/webapp/wdkCustomization/js/client/pluginConfig.tsx
+++ b/Site/webapp/wdkCustomization/js/client/pluginConfig.tsx
@@ -22,7 +22,7 @@ import { DynSpansBySourceId } from './components/questions/DynSpansBySourceId';
 import { GenesByBindingSiteFeature } from './components/questions/GenesByBindingSiteFeature';
 import { GenesByOrthologPattern } from './components/questions/GenesByOrthologPattern';
 import { InternalGeneDataset } from './components/questions/InternalGeneDataset';
-import { hasChromosomeAndSequenceIDXorGrouping } from './components/questions/MutuallyExclusiveParams/utils';
+import { hasChromosomeAndSequenceIDXorGroup } from './components/questions/MutuallyExclusiveParams/utils';
 import { CompoundsByFoldChangeForm, GenericFoldChangeForm } from './components/questions/foldChange';
 
 const isInternalGeneDatasetQuestion: ClientPluginRegistryEntry<any>['test'] =
@@ -35,7 +35,7 @@ const isMutuallyExclusiveParamQuestion: ClientPluginRegistryEntry<any>['test'] =
   ({ question }) => (
     question != null &&
     question.urlSegment.endsWith('ByLocation') &&
-    hasChromosomeAndSequenceIDXorGrouping(question)
+    hasChromosomeAndSequenceIDXorGroup(question)
   );
 
 const apiPluginConfig: ClientPluginRegistryEntry<any>[] = [

--- a/Site/webapp/wdkCustomization/js/client/pluginConfig.tsx
+++ b/Site/webapp/wdkCustomization/js/client/pluginConfig.tsx
@@ -15,14 +15,15 @@ import { ClientPluginRegistryEntry } from 'wdk-client/Utils/ClientPlugin';
 import { ByGenotypeNumberCheckbox } from './components/questions/ByGenotypeNumberCheckbox';
 
 import PopsetResultSummaryViewTableController from './components/controllers/PopsetResultSummaryViewTableController';
+import { BlastQuestionForm } from './components/questions/BlastQuestionForm';
 import { ByGenotypeNumber } from './components/questions/ByGenotypeNumber';
 import { ByLocationForm, ByLocationStepDetails } from './components/questions/ByLocation';
-import { BlastQuestionForm } from './components/questions/BlastQuestionForm';
 import { DynSpansBySourceId } from './components/questions/DynSpansBySourceId';
-import { CompoundsByFoldChangeForm, GenericFoldChangeForm } from './components/questions/foldChange';
 import { GenesByBindingSiteFeature } from './components/questions/GenesByBindingSiteFeature';
 import { GenesByOrthologPattern } from './components/questions/GenesByOrthologPattern';
 import { InternalGeneDataset } from './components/questions/InternalGeneDataset';
+import { hasChromosomeAndSequenceIDXorGrouping } from './components/questions/MutuallyExclusiveParams/utils';
+import { CompoundsByFoldChangeForm, GenericFoldChangeForm } from './components/questions/foldChange';
 
 const isInternalGeneDatasetQuestion: ClientPluginRegistryEntry<any>['test'] =
   ({ question }) => (
@@ -31,7 +32,11 @@ const isInternalGeneDatasetQuestion: ClientPluginRegistryEntry<any>['test'] =
   );
 
 const isMutuallyExclusiveParamQuestion: ClientPluginRegistryEntry<any>['test'] =
-  ({ question }) => question?.urlSegment.endsWith('ByLocation') ?? false;
+  ({ question }) => (
+    question != null &&
+    question.urlSegment.endsWith('ByLocation') &&
+    hasChromosomeAndSequenceIDXorGrouping(question)
+  );
 
 const apiPluginConfig: ClientPluginRegistryEntry<any>[] = [
   {


### PR DESCRIPTION
This PR fixes two related bugs concerning the `ByLocation` and `DynSpansBySourceId` custom question pages, as described in [this Redmine](https://redmine.apidb.org/issues/43096) and [this Trello](https://trello.com/c/iYQoMz0y/1462-trichdb-in-dynspansbysourceid-search-page-clicking-add-location-causes-an-alert-please-select-a-chromosome-or-search-by-sequence).

1. To fix `ByLocation`: I updated the associated client plugin predicate so that the form is only rendered when the question name ends with `ByLocation` AND a mutually exclusive param group is present.

2. To fix `DynSpansBySourceId`: if a chromosome parameter is unavailable, I set the `inputMethod` to `Sequence ID`.