### PR TITLE
Organism Param plugin

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/components/OrganismFilter.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/OrganismFilter.tsx
@@ -13,6 +13,8 @@ import {makeClassNameHelper} from 'wdk-client/Utils/ComponentUtils';
 import { areTermsInString, makeSearchHelpText } from 'wdk-client/Utils/SearchUtils';
 import { useWdkServiceWithRefresh } from 'wdk-client/Hooks/WdkServiceHook';
 
+import { pruneNodesWithSingleExtendingChild } from 'ebrc-client/util/organisms';
+
 import './OrganismFilter.scss';
 
 const cx = makeClassNameHelper('OrganismFilter')
@@ -356,8 +358,8 @@ function fetchTaxonomyTree(wdkService: WdkService) {
   return wdkService.getQuestionAndParameters(TAXON_QUESTION_NAME)
     .then(question => {
       let orgParam  = question.parameters.find(p => p.name == ORGANISM_PARAM_NAME);
-      if (orgParam && orgParam.type == 'multi-pick-vocabulary' && orgParam.displayType == "treeBox") {
-        return orgParam.vocabulary;
+      if (orgParam?.type == 'multi-pick-vocabulary' && orgParam?.displayType == 'treeBox') {
+        return pruneNodesWithSingleExtendingChild(orgParam.vocabulary);
       }
       else {
         throw new Error(TAXON_QUESTION_NAME + " does not contain treebox enum param " + ORGANISM_PARAM_NAME);

--- a/Site/webapp/wdkCustomization/js/client/components/questions/OrganismParam.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/questions/OrganismParam.tsx
@@ -1,0 +1,58 @@
+import React, { useMemo } from 'react';
+
+import { EnumParam, Parameter } from 'wdk-client/Utils/WdkModel';
+import ParamComponent from 'wdk-client/Views/Question/ParameterComponent';
+import EnumParamModule from 'wdk-client/Views/Question/Params/EnumParam';
+import { Props, isPropsType } from 'wdk-client/Views/Question/Params/Utils';
+
+import { pruneNodesWithSingleExtendingChild } from 'ebrc-client/util/organisms';
+
+const ORGANISM_PROPERTIES_KEY = 'organismProperties';
+
+const PRUNE_NODES_WITH_SINGLE_EXTENDING_CHILD_PROPERTY = 'pruneNodesWithSingleExtendingChild';
+
+export function OrganismParam<S = void>(props: Props<Parameter, S>) {
+  if (!isOrganismParamProps(props)) {
+    throw new Error(`Tried to render non-organism parameter ${props.parameter.name} with OrganismParam.`);
+  }
+
+  return <ValidatedOrganismParam {...props} />;
+}
+
+export function ValidatedOrganismParam<S = void>({ parameter, ...otherProps }: Props<EnumParam, S>) {
+  const paramWithPrunedVocab = useParamWithPrunedVocab(parameter);
+
+  return (
+    <ParamComponent
+      parameter={paramWithPrunedVocab}
+      {...otherProps}
+    />
+  );
+}
+
+function useParamWithPrunedVocab(parameter: EnumParam) {
+  return useMemo(
+    () => {
+      const shouldPruneNodesWithSingleExtendingChild = parameter.properties?.[ORGANISM_PROPERTIES_KEY].includes(PRUNE_NODES_WITH_SINGLE_EXTENDING_CHILD_PROPERTY);
+
+      return parameter.displayType === 'treeBox' && shouldPruneNodesWithSingleExtendingChild
+        ? ({
+            ...parameter,
+            vocabulary: pruneNodesWithSingleExtendingChild(parameter.vocabulary)
+          })
+        : parameter;
+    },
+    [ parameter ]
+  );
+}
+
+function isOrganismParamProps<S = void>(props: Props<Parameter, S>): props is Props<EnumParam, S> {
+  return isPropsType(props, isOrganismParam);
+}
+
+export function isOrganismParam(parameter: Parameter): parameter is EnumParam {
+  return (
+    parameter?.properties?.[ORGANISM_PROPERTIES_KEY] != null &&
+    EnumParamModule.isType(parameter)
+  );
+}

--- a/Site/webapp/wdkCustomization/js/client/components/records/PathwaySearchById.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/records/PathwaySearchById.tsx
@@ -8,7 +8,7 @@ import { isEqual, orderBy, uniqWith } from 'lodash';
 
 import { HelpIcon } from 'wdk-client/Components';
 import { safeHtml } from 'wdk-client/Utils/ComponentUtils';
-import { stripHTML } from 'wdk-client/Views/Records/RecordUtils';
+import { stripHTML } from 'wdk-client/Utils/DomUtils';
 
 import { NodeSearchCriteria } from './pathway-utils';
 

--- a/Site/webapp/wdkCustomization/js/client/components/records/utils.js
+++ b/Site/webapp/wdkCustomization/js/client/components/records/utils.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { compose, defaultTo, memoize, property } from 'lodash/fp';
 
 import { RecordActions } from 'wdk-client/Actions';
-import { stripHTML } from 'wdk-client/Views/Records/RecordUtils';
+import { stripHTML } from 'wdk-client/Utils/DomUtils';
 
 /**
  * Higher order component to ensure that record fields

--- a/Site/webapp/wdkCustomization/js/client/pluginConfig.tsx
+++ b/Site/webapp/wdkCustomization/js/client/pluginConfig.tsx
@@ -25,6 +25,8 @@ import { InternalGeneDataset } from './components/questions/InternalGeneDataset'
 import { hasChromosomeAndSequenceIDXorGroup } from './components/questions/MutuallyExclusiveParams/utils';
 import { CompoundsByFoldChangeForm, GenericFoldChangeForm } from './components/questions/foldChange';
 
+import { OrganismParam, isOrganismParam } from './components/questions/OrganismParam';
+
 const isInternalGeneDatasetQuestion: ClientPluginRegistryEntry<any>['test'] =
   ({ question }) => (
     question?.properties?.datasetCategory != null &&
@@ -148,6 +150,14 @@ const apiPluginConfig: ClientPluginRegistryEntry<any>[] = [
     name: 'genotype',
     searchName: 'ByGenotypeNumber',
     component: ByGenotypeNumberCheckbox
+  },
+  {
+    type: 'questionFormParameter',
+    test: ({ parameter }) => (
+      parameter != null &&
+      isOrganismParam(parameter)
+    ),
+    component: OrganismParam
   },
   {
     type: 'stepAnalysisResult',

--- a/Site/webapp/wdkCustomization/js/client/pluginConfig.tsx
+++ b/Site/webapp/wdkCustomization/js/client/pluginConfig.tsx
@@ -23,9 +23,9 @@ import { GenesByBindingSiteFeature } from './components/questions/GenesByBinding
 import { GenesByOrthologPattern } from './components/questions/GenesByOrthologPattern';
 import { InternalGeneDataset } from './components/questions/InternalGeneDataset';
 import { hasChromosomeAndSequenceIDXorGroup } from './components/questions/MutuallyExclusiveParams/utils';
+import { OrganismParam, isOrganismParam } from './components/questions/OrganismParam';
 import { CompoundsByFoldChangeForm, GenericFoldChangeForm } from './components/questions/foldChange';
 
-import { OrganismParam, isOrganismParam } from './components/questions/OrganismParam';
 
 const isInternalGeneDatasetQuestion: ClientPluginRegistryEntry<any>['test'] =
   ({ question }) => (


### PR DESCRIPTION
**Note:** Depends on https://github.com/VEuPathDB/WDKClient/pull/114 and https://github.com/VEuPathDB/EbrcWebsiteCommon/pull/41, the latter of which defines "extending child."

This PR introduces an `OrganismParam` `questionFormParameter` plugin which is intended to render organism params in search pages.

In short, an `OrganismParam` is an `EnumParam` with an `organismProperties` list. Currently only one property, `pruneNodesWithSingleDescendingChild` is supported. When `pruneNodesWithSingleDescendingChild` is present, and the parameter's display type is `treeBox`, all of the vocabulary nodes with a single extending child are pruned.

**Note:** In addition, the organism filter's taxonomy tree is updated so that nodes with a single extending child are pruned.