### PR TITLE
SRT: pass hidden "downloadType" param expected by our Srt scripts

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/components/Srt.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/Srt.tsx
@@ -174,6 +174,7 @@ function SrtForm({
   return (
     <form action={formActionUrl} method="post" target="_blank">
       <input type="hidden" name="project_id" value={projectId} />
+      <input type="hidden" name="downloadType" value={String(formState.attachmentType)} />
       <h3 className={cx('--IdsHeader')} >
         Enter a list of {display} (each ID on a separate line):
         {' '}


### PR DESCRIPTION
This PR fixes a bug in the SRT tool where selecting the "Text File" download type was causing the result to appear in the browser. The fix is to pass a hidden `downloadType` param expected by our Srt scripts.