### PR TITLE
Organism genome record cleanup

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/storeModules/Record.js
+++ b/Site/webapp/wdkCustomization/js/client/storeModules/Record.js
@@ -199,7 +199,7 @@ function pruneByDatasetCategory(categoryTree, record) {
   console.log(record)
 
 
-  // Remove Dataset Version from genome datasets
+  // Remove Dataset Version from genome datasets, otherwise remove genome tables from non-genome datasets
   if (record.attributes.newcategory === 'Annotation, curation and identifiers') {
 
     categoryTree = tree.pruneDescendantNodes(
@@ -213,7 +213,20 @@ function pruneByDatasetCategory(categoryTree, record) {
       categoryTree
     )
 
-  }
+  } else {
+    categoryTree = tree.pruneDescendantNodes(
+      individual => {
+        if (individual.children.length > 0) return true;
+        if (individual.wdkReference == null) return false;
+        if (individual.wdkReference.name === 'TranscriptTypeCounts') return false;
+        if (individual.wdkReference.name === 'SequenceTypeCounts') return false;
+        if (individual.wdkReference.name === 'GenomeAssociatedData') return false;
+        if (individual.wdkReference.name === 'ExternalDatabases') return false;
+        return true;
+      },
+      categoryTree
+    )
+  }     
 
   // Example graphs should only be shown on RNASeq, Microarray, Phenotype datasets
   if (!['RNASeq', 'DNA Microarray', 'Phenotype'].includes(record.attributes.newcategory)) {

--- a/Site/webapp/wdkCustomization/js/client/storeModules/Record.js
+++ b/Site/webapp/wdkCustomization/js/client/storeModules/Record.js
@@ -124,6 +124,12 @@ function pruneCategories(nextState) {
     categoryTree = pruneCategoryBasedOnShowStrains(pruneCategoriesByMetaTable(removeProteinCategories(categoryTree, record), record), record);
     nextState = Object.assign({}, nextState, { categoryTree });
   }
+  if (isDatasetRecord(record)) {
+    console.log(categoryTree)
+    console.log(record)
+    categoryTree = pruneByDatasetCategory(categoryTree, record);
+    nextState = Object.assign({}, nextState, { categoryTree }); 
+  }
   return nextState;
 }
 
@@ -189,6 +195,28 @@ function pruneCategoriesByMetaTable(categoryTree, record) {
     categoryTree
   )
 }
+
+function pruneByDatasetCategory(categoryTree, record) {
+  console.log(categoryTree)
+  console.log(record)
+
+
+  if (record.attributes.newcategory === 'Annotation, curation and identifiers') {
+
+    return tree.pruneDescendantNodes(
+      individual => {
+        console.log(individual);
+        if (individual.wdkReference == null) return false;
+        if (individual.wdkReference.name === 'version') return false;
+        return true;
+      },
+      categoryTree
+    )
+
+  }
+  return categoryTree
+}
+
 
 
 // Custom observers
@@ -330,4 +358,8 @@ function isGeneRecord(record) {
 
 function isSnpsRecord(record) {
   return record.recordClassName === 'SnpRecordClasses.SnpRecordClass';
+}
+
+function isDatasetRecord(record) {
+  return record.recordClassName === 'DatasetRecordClasses.DatasetRecordClass';
 }

--- a/Site/webapp/wdkCustomization/js/client/storeModules/Record.js
+++ b/Site/webapp/wdkCustomization/js/client/storeModules/Record.js
@@ -199,7 +199,8 @@ function pruneByDatasetCategory(categoryTree, record) {
   console.log(record)
 
 
-  // Remove Dataset Version from genome datasets, otherwise remove genome tables from non-genome datasets
+  // Remove Dataset Version and Source Version from genome datasets, otherwise remove genome tables from non-genome datasets
+  // Additionally, choose either the genome dataset history or non-genome dataset history table
   if (record.attributes.newcategory === 'Annotation, curation and identifiers') {
 
     categoryTree = tree.pruneDescendantNodes(
@@ -208,6 +209,8 @@ function pruneByDatasetCategory(categoryTree, record) {
         if (individual.children.length > 0) return true;
         if (individual.wdkReference == null) return false;
         if (individual.wdkReference.name === 'version') return false;
+        if (individual.wdkReference.name === 'Version') return false;
+        if (individual.wdkReference.name === 'DatasetHistory') return false;
         return true;
       },
       categoryTree
@@ -222,6 +225,7 @@ function pruneByDatasetCategory(categoryTree, record) {
         if (individual.wdkReference.name === 'SequenceTypeCounts') return false;
         if (individual.wdkReference.name === 'GenomeAssociatedData') return false;
         if (individual.wdkReference.name === 'ExternalDatabases') return false;
+        if (individual.wdkReference.name === 'GenomeHistory') return false;
         return true;
       },
       categoryTree

--- a/Site/webapp/wdkCustomization/js/client/storeModules/Record.js
+++ b/Site/webapp/wdkCustomization/js/client/storeModules/Record.js
@@ -125,8 +125,6 @@ function pruneCategories(nextState) {
     nextState = Object.assign({}, nextState, { categoryTree });
   }
   if (isDatasetRecord(record)) {
-    console.log(categoryTree)
-    console.log(record)
     categoryTree = pruneByDatasetCategory(categoryTree, record);
     nextState = Object.assign({}, nextState, { categoryTree }); 
   }
@@ -201,11 +199,13 @@ function pruneByDatasetCategory(categoryTree, record) {
   console.log(record)
 
 
+  // Remove Dataset Version from genome datasets
   if (record.attributes.newcategory === 'Annotation, curation and identifiers') {
 
-    return tree.pruneDescendantNodes(
+    categoryTree = tree.pruneDescendantNodes(
       individual => {
         console.log(individual);
+        if (individual.children.length > 0) return true;
         if (individual.wdkReference == null) return false;
         if (individual.wdkReference.name === 'version') return false;
         return true;
@@ -214,6 +214,20 @@ function pruneByDatasetCategory(categoryTree, record) {
     )
 
   }
+
+  // Example graphs should only be shown on RNASeq, Microarray, Phenotype datasets
+  if (!['RNASeq', 'DNA Microarray', 'Phenotype'].includes(record.attributes.newcategory)) {
+    categoryTree = tree.pruneDescendantNodes(
+      individual => {
+        if (individual.children.length > 0) return true;
+        if (individual.wdkReference == null) return false;
+        if (individual.wdkReference.name === 'ExampleGraphs') return false;
+        return true;
+      },
+      categoryTree
+    )
+  }
+ 
   return categoryTree
 }
 

--- a/Site/webapp/wdkCustomization/js/client/storeModules/Record.js
+++ b/Site/webapp/wdkCustomization/js/client/storeModules/Record.js
@@ -199,7 +199,7 @@ function pruneByDatasetCategory(categoryTree, record) {
 
   // Remove Dataset Version and Source Version from genome datasets, otherwise remove genome tables from non-genome datasets
   // Additionally, choose either the genome dataset history (GenomeHistory) or non-genome dataset history table (DatasetHistory).
-  if (record.attributes.newcategory === 'Annotation, curation and identifiers') {
+  if (record.attributes.newcategory === 'Genomics') {
 
     categoryTree = tree.pruneDescendantNodes(
       individual => {

--- a/Site/webapp/wdkCustomization/js/client/storeModules/Record.js
+++ b/Site/webapp/wdkCustomization/js/client/storeModules/Record.js
@@ -195,17 +195,14 @@ function pruneCategoriesByMetaTable(categoryTree, record) {
 }
 
 function pruneByDatasetCategory(categoryTree, record) {
-  console.log(categoryTree)
-  console.log(record)
 
 
   // Remove Dataset Version and Source Version from genome datasets, otherwise remove genome tables from non-genome datasets
-  // Additionally, choose either the genome dataset history or non-genome dataset history table
+  // Additionally, choose either the genome dataset history (GenomeHistory) or non-genome dataset history table (DatasetHistory).
   if (record.attributes.newcategory === 'Annotation, curation and identifiers') {
 
     categoryTree = tree.pruneDescendantNodes(
       individual => {
-        console.log(individual);
         if (individual.children.length > 0) return true;
         if (individual.wdkReference == null) return false;
         if (individual.wdkReference.name === 'version') return false;

--- a/Site/webapp/wdkCustomization/js/client/storeModules/Record.js
+++ b/Site/webapp/wdkCustomization/js/client/storeModules/Record.js
@@ -222,6 +222,7 @@ function pruneByDatasetCategory(categoryTree, record) {
         if (individual.children.length > 0) return true;
         if (individual.wdkReference == null) return false;
         if (individual.wdkReference.name === 'TranscriptTypeCounts') return false;
+        if (individual.wdkReference.name === 'GeneTypeCounts') return false;
         if (individual.wdkReference.name === 'SequenceTypeCounts') return false;
         if (individual.wdkReference.name === 'GenomeAssociatedData') return false;
         if (individual.wdkReference.name === 'ExternalDatabases') return false;


### PR DESCRIPTION
The goal of this PR is to collect and simplify data shown on the dataset record pages. 

_Relies on associated PRs [56](https://github.com/VEuPathDB/EbrcWebsiteCommon/pull/56) in EbrcWebsiteCommon and [7](https://github.com/VEuPathDB/EbrcModelCommon/pull/7) in EbrcModelCommon_

## Major Update
- Function `pruneByDatasetCategory` allows tree leaves to be included/excluded based on the dataset's category. Specifically, many tables and attributes are not appropriate for non-genomics datasets, and `ExampleGraphs` is only appropriate for some datasets.

## Notes
- See related PRs for more details.