### PR TITLE
Add EC-related params to pathway enrichment tool; Redmine 41831

### DIFF
--- a/Model/bin/apiPathwaysEnrichment
+++ b/Model/bin/apiPathwaysEnrichment
@@ -9,7 +9,7 @@ my $pathwaysEnrich = ApiCommonWebsite::Model::PathwaysEnrichment->new();
 print STDERR join("| ", @ARGV);
 my $length = scalar(@ARGV);
 print STDERR "argument length is $length\n";
-$pathwaysEnrich->usage() unless scalar(@ARGV) == 7;
+$pathwaysEnrich->usage() unless scalar(@ARGV) == 9;
 
 
 $pathwaysEnrich->run(@ARGV);

--- a/Model/lib/perl/PathwaysEnrichment.pm
+++ b/Model/lib/perl/PathwaysEnrichment.pm
@@ -34,6 +34,8 @@ SELECT count (distinct tp.gene_source_id)
          from    apidbtuning.transcriptPathway tp, ApidbTuning.GeneAttributes ga
         where  ga.taxon_id = $taxonId
         AND    tp.gene_source_id = ga.source_id
+        AND tp.complete_ec >= $self->{excludeIncomplete}
+        AND tp.exact_match >= $self->{exactMatchOnly}
 ";
 
   my $stmt = $self->runSql($dbh, $sql);
@@ -50,6 +52,8 @@ SELECT count (distinct tp.gene_source_id)
          from  apidbtuning.transcriptPathway tp,
                ($geneResultSql) r
         where  tp.gene_source_id = r.source_id
+        AND tp.complete_ec >= $self->{excludeIncomplete}
+        AND tp.exact_match >= $self->{exactMatchOnly}
 ";
 
   my $stmt = $self->runSql($dbh, $sql);
@@ -60,11 +64,15 @@ SELECT count (distinct tp.gene_source_id)
 sub getAnnotatedGenesListResult {
   my ($self, $dbh, $geneResultSql) = @_;
 
+  # note: prior to introducing the exact_match and complete_ec params to the UI
+  # the query below already had `tp.exact_match = 1`
+  # so we are currently retaining this (but should we?)
   my $sql = "
 SELECT distinct tp.gene_source_id
          from  apidbtuning.transcriptPathway tp,
                ($geneResultSql) r
         where  tp.gene_source_id = r.source_id
+          AND tp.complete_ec >= $self->{excludeIncomplete}
           and tp.exact_match = 1
           and tp.pathway_source in ($self->{source})
 ";
@@ -139,6 +147,8 @@ from
         , apidbtuning.pathwayreactions pr
         where  ga.taxon_id = $taxonId
         and   tp.gene_source_id = ga.source_id
+        AND tp.complete_ec >= $self->{excludeIncomplete}
+        AND tp.exact_match >= $self->{exactMatchOnly}
         and pc.pathway_id = tp.pathway_id
         and pr.reaction_id = pc.reaction_id
         and pr.ext_db_name = pc.ext_db_name
@@ -153,6 +163,8 @@ from
         , apidbtuning.pathwaycompounds pc
         , apidbtuning.pathwayreactions pr
         where  tp.gene_source_id = r.source_id
+        AND tp.complete_ec >= $self->{excludeIncomplete}
+        AND tp.exact_match >= $self->{exactMatchOnly}
         and tp.pathway_source in ($self->{source})
         and pc.pathway_id = tp.pathway_id
         and pr.reaction_id = pc.reaction_id
@@ -167,6 +179,8 @@ from
         , apidbtuning.pathwaycompounds pc
         , apidbtuning.pathwayreactions pr
         where  tp.gene_source_id = r.source_id
+        AND tp.complete_ec >= $self->{excludeIncomplete}
+        AND tp.exact_match >= $self->{exactMatchOnly}
         and tp.pathway_source in ($self->{source})
         and pc.pathway_id = tp.pathway_id
         and pr.reaction_id = pc.reaction_id

--- a/Model/lib/perl/PathwaysEnrichment.pm
+++ b/Model/lib/perl/PathwaysEnrichment.pm
@@ -66,14 +66,14 @@ sub getAnnotatedGenesListResult {
 
   # note: prior to introducing the exact_match and complete_ec params to the UI
   # the query below already had `tp.exact_match = 1`
-  # so we are currently retaining this (but should we?)
+  # THIS HAS BEEN REPLACED WITH `tp.exact_match >= $self->{exactMatchOnly}`
   my $sql = "
 SELECT distinct tp.gene_source_id
          from  apidbtuning.transcriptPathway tp,
                ($geneResultSql) r
         where  tp.gene_source_id = r.source_id
           AND tp.complete_ec >= $self->{excludeIncomplete}
-          and tp.exact_match = 1
+          and tp.exact_match >= $self->{exactMatchOnly}
           and tp.pathway_source in ($self->{source})
 ";
 

--- a/Model/lib/perl/PathwaysEnrichment.pm
+++ b/Model/lib/perl/PathwaysEnrichment.pm
@@ -15,12 +15,14 @@ sub new {
 }
 
 sub run {
-  my ($self, $outputFile, $geneResultSql, $modelName, $pValueCutoff, $source, $wordcloudFile, $secondOutputFile) = @_;
+  my ($self, $outputFile, $geneResultSql, $modelName, $pValueCutoff, $source, $wordcloudFile, $secondOutputFile, $exactMatchOnly, $excludeIncomplete) = @_;
 
   die "Second argument must be an SQL select statement that returns the Gene result\n" unless $geneResultSql =~ m/select/i;
   die "Fourth argument must be a p-value between 0 and 1\n" unless $pValueCutoff > 0 && $pValueCutoff <= 1;
 
-  $self->{source} = $source;
+  $self->{source} = $source; # not sure if this is taint-free
+  $self->{exactMatchOnly} = $exactMatchOnly =~ /yes/i ? 1 : 0; # taint-free
+  $self->{excludeIncomplete} = $excludeIncomplete =~ /yes/i ? 1 : 0; # taint-free
   $self->SUPER::run($outputFile, $geneResultSql, $modelName, $pValueCutoff, $secondOutputFile);
 }
 

--- a/Model/src/main/java/org/apidb/apicommon/model/stepanalysis/PathwaysEnrichmentPlugin.java
+++ b/Model/src/main/java/org/apidb/apicommon/model/stepanalysis/PathwaysEnrichmentPlugin.java
@@ -89,7 +89,7 @@ public class PathwaysEnrichmentPlugin extends AbstractSimpleProcessAnalyzer {
   private void validateFilteredPathways(ValidationBundleBuilder errors)
         throws WdkModelException {
     // This method never seems to get called...
-    LOG.info("SEE COMMENT IN redmine 41831");
+    LOG.info("See comments in redmines 41831 and 46472");
     String countColumn = "CNT";
 
     Map<String, String> formParams = getFormParams();


### PR DESCRIPTION
[Redmine ticket](https://redmine.apidb.org/issues/41831)

Related PR: https://github.com/VEuPathDB/ApiCommonModel/pull/2 

Testable on https://bmaccallum.eupathdb.org at the moment.  Let me know if the site is broken due to database changes outside my control.

From a gene-based query result, choose 
![image](https://user-images.githubusercontent.com/308639/138432422-5556e9c3-0cff-4aea-b706-e5384ceeed76.png)
and do a Pathways enrichment analysis.

New options are now available
![image](https://user-images.githubusercontent.com/308639/138432514-7f66d976-4ebd-40be-8ded-4b3379bd37d4.png)

All combos of the new parameters have been tested on a gene result ([all genes with user-annotations](https://bmaccallum.eupathdb.org/eupathdb.bmaccallum/app/workspace/strategies/import/cefe668a6386d34b)) 

Still needs testing with parameter choices that remove ALL pathway-annotated genes from the input gene list.