### PR TITLE
Report Record Page Organisms

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/wrapWdkService.tsx
+++ b/Site/webapp/wdkCustomization/js/client/wrapWdkService.tsx
@@ -1,11 +1,49 @@
-import { BlastCompatibleWdkService, blastCompatibleWdkServiceWrappers } from '@veupathdb/multi-blast/lib/utils/wdkServiceIntegration';
 import { WdkService } from '@veupathdb/wdk-client/lib/Core';
+import { ok } from '@veupathdb/wdk-client/lib/Utils/Json';
 
-type ApiCommonWdkService = BlastCompatibleWdkService;
+import { blastCompatibleWdkServiceWrappers } from '@veupathdb/multi-blast/lib/utils/wdkServiceIntegration';
 
-export function wrapWdkService(wdkService: WdkService): ApiCommonWdkService {
+export type GenomicsService = WdkService & {
+  [K in keyof GenomicsServiceWrappers]: ReturnType<GenomicsServiceWrappers[K]>;
+};
+
+type GenomicsServiceWrappers = typeof genomicsServiceWrappers;
+
+export const genomicsServiceWrappers = {
+  ...blastCompatibleWdkServiceWrappers,
+  incrementOrganismCount: (wdkService: WdkService) => function(
+    organismBearingEntity:
+      string | { recordClassUrlSegment: string, primaryKeyValues: string[] }
+  ): Promise<void> {
+    const queryParams = new URLSearchParams();
+
+    if (typeof organismBearingEntity === 'string') {
+      queryParams.append('organism', organismBearingEntity)
+    } else {
+      queryParams.append('recordType', organismBearingEntity.recordClassUrlSegment);
+      queryParams.append('primaryKey', organismBearingEntity.primaryKeyValues.join(','));
+    }
+
+    return wdkService.sendRequest(
+      ok,
+      {
+        method: 'get',
+        path: `/system/metrics/organism?${queryParams}`
+      }
+    );
+  }
+};
+
+export function wrapWdkService(wdkService: WdkService): GenomicsService {
   return {
     ...wdkService,
-    getBlastParamInternalValues: blastCompatibleWdkServiceWrappers.getBlastParamInternalValues(wdkService)
+    getBlastParamInternalValues: genomicsServiceWrappers.getBlastParamInternalValues(wdkService),
+    incrementOrganismCount: genomicsServiceWrappers.incrementOrganismCount(wdkService),
   };
+}
+
+export function isGenomicsService(wdkService: WdkService): wdkService is GenomicsService  {
+  return Object.keys(genomicsServiceWrappers).every(
+    genomicsServiceWrapperKey => genomicsServiceWrapperKey in wdkService
+  );
 }


### PR DESCRIPTION
This PR:

1. Introduces an `incrementOrganismCount` service method which receives an organism name or WDK record primary key and requests that the associated `page_access_by_organism_total` Prometheus metric be updated
2. Uses this method to `incrementOrganismCount` whenever a gene or genomic sequence record page is visited