### PR TITLE
Migrate files from WDKClient and update paths

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router';
 
 import { Loading, Link, Tooltip, HelpIcon, Tabs } from '@veupathdb/wdk-client/lib/Components';
-import { StepAnalysisEnrichmentResultTable as InternalGeneDatasetTable } from '@veupathdb/wdk-client/lib/Components/StepAnalysis/StepAnalysisEnrichmentResultTable';
+import { CommonResultTable as InternalGeneDatasetTable } from '@veupathdb/wdk-client/lib/Components/Shared/CommonResultTable';
 import QuestionController, {
   useSetSearchDocumentTitle,
   OwnProps as Props

--- a/Site/webapp/wdkCustomization/js/client/components/stepAnalysis/StepAnalysisEnrichmentResult.scss
+++ b/Site/webapp/wdkCustomization/js/client/components/stepAnalysis/StepAnalysisEnrichmentResult.scss
@@ -1,0 +1,90 @@
+.step-analysis-pane {
+  .MesaComponent {
+    // nested .MesaComponent
+    > .MesaComponent {
+      width: 100%;
+      overflow: auto;
+    }
+  }
+}
+
+.enrich-result-p {
+  font-size: 90%;
+  font-weight: normal;
+  margin: 0;
+  text-align: right;
+}
+
+.enrich-result-q {
+  font-size: 90%;
+  font-weight: normal;
+  margin: 0;
+  text-align: right;
+}
+
+.enrich-table {
+  th {
+    text-align: left;
+  }
+
+  td {
+    text-align: left;
+  }
+
+  td.enrich-centered {
+    text-align: center;
+  }
+}
+
+.enrich-databar {
+  border:0; margin:0; padding:0;
+  display: inline-block;
+  height: 1em;
+  background-color: lightgreen;
+}
+
+.enrich-download-link {
+  float: right;
+  font-weight: bold;
+  font-size: 110%;
+  width: 1200px;
+  text-align: right;
+}
+
+.enrich-empty-results {
+  font-weight: bold;
+  margin: 25px auto;
+  text-align: center;
+}
+
+.Revigo-analysis {
+  float: right;
+  width: 1200px;
+}
+
+#revigoSubmit {
+  float:right;
+  color:#FFFFFF;
+  background: #4F81BD;
+  border-color: #346792;
+  box-shadow: 0px 0px 1px #245F92;
+  padding: 1px 1em;
+  margin-left: .5em;
+  font-weight: normal;
+  font-size: smaller;
+  border-radius: 4px;
+  line-height: normal;
+}
+
+.wdk-Dialog.word-cloud-modal {
+  height: 400px;
+  width: 700px;
+
+  .word-cloud-modalContent {
+    display: block;
+  }
+
+  img {
+    width: 700px;
+  }
+}

--- a/Site/webapp/wdkCustomization/js/client/components/stepAnalysis/StepAnalysisGoEnrichmentResults.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/stepAnalysis/StepAnalysisGoEnrichmentResults.tsx
@@ -1,0 +1,177 @@
+import { scientificCellFactory, decimalCellFactory, integerCell } from '@veupathdb/wdk-client/lib/Components/StepAnalysis/Utils/StepAnalysisResults';
+import { StepAnalysisResultPluginProps } from '@veupathdb/wdk-client/lib/Components/StepAnalysis/StepAnalysisResultsPane';
+import { ColumnSettings, CommonResultTable } from '@veupathdb/wdk-client/lib/Components/Shared/CommonResultTable';
+import React, { Fragment, useState } from 'react';
+import { StepAnalysisButtonArray } from '@veupathdb/wdk-client/lib/Components/StepAnalysis/StepAnalysisButtonArray';
+import { WordCloudModal } from './StepAnalysisWordCloudModal';
+
+import './StepAnalysisEnrichmentResult.scss';
+
+const goEnrichmentResultColumns = [
+  {
+    key: 'goId',
+    name: 'GO ID',
+    helpText: 'Gene Ontology ID',
+    sortable: true
+  },
+  {
+    key: 'goTerm',
+    name: 'GO Term',
+    helpText: 'Gene Ontology Term',
+    sortable: true
+  },
+  {
+    key: 'bgdGenes',
+    name: 'Genes in the bkgd with this term',
+    helpText: 'Number of genes with this term in the background',
+    renderCell: integerCell('bgdGenes'),
+    sortable: true,
+    sortType: 'number'
+  },
+  {
+    key: 'resultGenes',
+    name: 'Genes in your result with this term',
+    helpText: 'Number of genes with this term in your result',
+    type: 'html',
+    sortable: true,
+    sortType: 'htmlNumber'
+  },
+  {
+    key: 'percentInResult',
+    name: 'Percent of bkgd genes in your result',
+    helpText: 'Of the genes in the background with this term, the percent that are present in your result',
+    renderCell: decimalCellFactory(1)('percentInResult'),
+    sortable: true,
+    sortType: 'number'
+  },
+  {
+    key: 'foldEnrich',
+    name: 'Fold enrichment',
+    helpText: 'The percent of genes with this term in your result divided by the percent of genes with this term in the background',
+    renderCell: decimalCellFactory(2)('foldEnrich'),
+    sortable: true,
+    sortType: 'number'
+  },
+  {
+    key: 'oddsRatio',
+    name: 'Odds ratio',
+    helpText: 'Odds ratio statistic from the Fisher\'s exact test',
+    renderCell: decimalCellFactory(2)('oddsRatio'),
+    sortable: true,
+    sortType: 'number'
+  },
+  {
+    key: 'pValue',
+    name: 'P-value',
+    helpText: 'P-value from Fisher\'s exact test',
+    renderCell: scientificCellFactory(2)('pValue'),
+    sortable: true,
+    sortType: 'number'
+  },
+  {
+    key: 'benjamini',
+    name: 'Benjamini',
+    helpText: 'Benjamini-Hochberg false discovery rate (FDR)',
+    renderCell: scientificCellFactory(2)('benjamini'),
+    sortable: true,
+    sortType: 'number'
+  },
+  {
+    key: 'bonferroni',
+    name: 'Bonferroni',
+    helpText: 'Bonferroni adjusted p-value',
+    renderCell: scientificCellFactory(2)('bonferroni'),
+    sortable: true,
+    sortType: 'number'
+  }
+] as ColumnSettings[];
+
+const goIdRenderFactory = (goTermBaseUrl: string) => ({ row }: Record<string, any>) =>
+  <a
+    title="Check this term in the GO hierarchy (Amigo website)"
+    href={`${goTermBaseUrl}${row.goId}#display-lineage-tab`}
+    target="_blank"
+  >
+    {row.goId}
+  </a>;
+
+const goButtonsConfigFactory = (
+  stepId: number,
+  analysisId: number,
+  { imageDownloadPath, hiddenDownloadPath, revidoInputList }: any,
+  webAppUrl: string,
+  setWordCloudOpen: (wordCloudOpen: boolean) => void
+) => [
+    {
+      key: 'revigo',
+      customButton: (
+        <form target="_blank" action="http://revigo.irb.hr/" method="post">
+          <textarea name="inputGoList" rows={10} cols={80} hidden readOnly value={revidoInputList} />
+          <input name="isPValue" hidden readOnly value="yes" />
+          <input name="outputListSize" hidden readOnly value="medium" />
+          <button type="submit" name="startRevigo" className="btn" style={{ fontSize: '12px' }}>
+            <i className="fa fa-bar-chart red-text" style={{ marginLeft: 0, paddingLeft: 0 }}> </i>
+          Open in <b>Revigo</b>
+          </button>
+        </form>
+      )
+    },
+    {
+      key: 'wordCloud',
+      onClick: (event: React.MouseEvent<HTMLAnchorElement>) => {
+        event.preventDefault();
+        setWordCloudOpen(true);
+      },
+      href: `${webAppUrl}/service/users/current/steps/${stepId}/analyses/${analysisId}/resources?path=${imageDownloadPath}`,
+      iconClassName: 'fa fa-bar-chart red-text',
+      contents: <Fragment>Show <b>Word Cloud</b></Fragment>
+    },
+    {
+      key: 'download',
+      href: `${webAppUrl}/service/users/current/steps/${stepId}/analyses/${analysisId}/resources?path=${hiddenDownloadPath}`,
+      iconClassName: 'fa fa-download blue-text',
+      contents: 'Download'
+    }
+  ];
+
+export const StepAnalysisGoEnrichmentResults: React.FunctionComponent<StepAnalysisResultPluginProps> = ({
+  analysisResult,
+  analysisConfig,
+  webAppUrl
+}) => {
+  const [wordCloudOpen, setWordCloudOpen] = useState(false);
+
+  return (
+    <Fragment>
+      <StepAnalysisButtonArray configs={goButtonsConfigFactory(
+        analysisConfig.stepId,
+        analysisConfig.analysisId,
+        analysisResult,
+        webAppUrl,
+        setWordCloudOpen
+      )} />
+      <h3>Analysis Results:   </h3>
+      <CommonResultTable
+        emptyResultMessage={'No enrichment was found with significance at the P-value threshold you specified.'}
+        rows={analysisResult.resultData}
+        columns={goEnrichmentResultColumns.map(column =>
+          column.key === 'goId'
+            ? { ...column, renderCell: goIdRenderFactory(analysisResult.goTermBaseUrl) }
+            : column
+        )}
+        initialSortColumnKey={'pValue'}
+        fixedTableHeader
+      />
+      <WordCloudModal
+        imgUrl={
+          `${webAppUrl}/service/users/current/steps/${analysisConfig.stepId}/analyses/${analysisConfig.analysisId}/resources?path=${analysisResult.imageDownloadPath}&_=${Date.now()}`
+        }
+        open={wordCloudOpen}
+        onClose={() => {
+          setWordCloudOpen(false);
+        }}
+        toolName={'GO Enrichment Analysis'}
+      />
+    </Fragment>
+  );
+};

--- a/Site/webapp/wdkCustomization/js/client/components/stepAnalysis/StepAnalysisHpiGeneListResults.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/stepAnalysis/StepAnalysisHpiGeneListResults.tsx
@@ -1,0 +1,93 @@
+import React, { Fragment } from 'react';
+import { StepAnalysisResultPluginProps } from '@veupathdb/wdk-client/lib/Components/StepAnalysis/StepAnalysisResultsPane'
+import { CommonResultTable, ColumnSettings } from '@veupathdb/wdk-client/lib/Components/Shared/CommonResultTable';
+import Templates from '@veupathdb/wdk-client/lib/Components/Mesa/Templates';
+
+import './StepAnalysisEnrichmentResult.scss';
+import { Tooltip } from '@veupathdb/wdk-client/lib/Components';
+
+const baseColumnSettings: Pick<ColumnSettings, 'key' | 'renderCell' | 'sortable' | 'sortType' | 'type'>[] = [
+  {
+    key: 'species',
+    type: 'html',
+    sortable: true,
+    sortType: 'htmlText'
+  },
+  {
+    key: 'experimentName',
+    renderCell: (cellProps: any) => (
+      <Tooltip
+        content={Templates.htmlCell({
+          ...cellProps,
+          key: 'description',
+          value: cellProps.row.description
+        })}
+      >
+        <a
+          title={cellProps.row.description}
+          href={`${cellProps.row.uri}`}
+          target="_blank">{cellProps.row.experimentName}
+        </a>
+      </Tooltip>
+    ),
+    sortable: true
+  },
+  {
+    key: 'type',
+    sortable: true
+  },
+  {
+    key: 'c11',
+    sortable: true,
+    sortType: 'number'
+  },
+  {
+    key: 'c22',
+    sortable: true,
+    sortType: 'number'
+  },
+  {
+    key: 'c33',
+    sortable: true,
+    sortType: 'number'
+  },
+  {
+    key: 'c44',
+    sortable: true,
+    sortType: 'number'
+  },
+  {
+    key: 'c55',
+    sortable: true,
+    sortType: 'number'
+  },
+  {
+    key: 'significance',
+    sortable: true,
+    sortType: 'number'
+  }
+];
+
+const hpiGeneListResultColumns = (headerRow: any, headerDescription: any): ColumnSettings[] => baseColumnSettings.map(column => ({
+  ...column,
+  name: headerRow[column.key],
+  helpText: headerDescription[column.key]
+}));
+
+export const StepAnalysisHpiGeneListResults: React.SFC<StepAnalysisResultPluginProps> = ({
+  analysisResult: {
+    resultData,
+    headerRow,
+    headerDescription
+  }
+}) => (
+  <>
+    <h3>Analysis Results:   </h3>
+    <CommonResultTable
+      emptyResultMessage={'No enrichment was found for the threshold you specified.'}
+      rows={resultData}
+      columns={hpiGeneListResultColumns(headerRow, headerDescription)}
+      fixedTableHeader
+    />
+  </>
+);

--- a/Site/webapp/wdkCustomization/js/client/components/stepAnalysis/StepAnalysisPathwayEnrichmentResults.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/stepAnalysis/StepAnalysisPathwayEnrichmentResults.tsx
@@ -1,0 +1,169 @@
+import { scientificCellFactory, decimalCellFactory, integerCell } from '@veupathdb/wdk-client/lib/Components/StepAnalysis/Utils/StepAnalysisResults';
+import { StepAnalysisResultPluginProps } from '@veupathdb/wdk-client/lib/Components/StepAnalysis/StepAnalysisResultsPane';
+import { ColumnSettings, CommonResultTable } from '@veupathdb/wdk-client/lib/Components/Shared/CommonResultTable';
+import React, { Fragment, useState } from 'react';
+import { StepAnalysisButtonArray } from '@veupathdb/wdk-client/lib/Components/StepAnalysis/StepAnalysisButtonArray';
+import { WordCloudModal } from './StepAnalysisWordCloudModal';
+
+import './StepAnalysisEnrichmentResult.scss';
+
+const pathwayEnrichmentResultColumns = [
+  {
+    key: 'pathwayId',
+    name: 'Pathway ID',
+    helpText: 'Pathway ID',
+    sortable: true
+  },
+  {
+    key: 'pathwayName',
+    name: 'Pathway Name',
+    helpText: 'Pathway Name',
+    type: 'html',
+    sortable: true,
+    sortType: 'htmlText'
+  },
+  {
+    key: 'pathwaySource',
+    name: 'Pathway Source',
+    helpText: 'Pathway Source',
+    sortable: true
+  },
+  {
+    key: 'bgdGenes',
+    name: 'Genes in the bkgd with this pathway',
+    helpText: 'Number of genes in this pathway in the background',
+    renderCell: integerCell('bgdGenes'),
+    sortable: true,
+    sortType: 'number'
+  },
+  {
+    key: 'resultGenes',
+    name: 'Genes in your result with this pathway',
+    helpText: 'Number of genes in this pathway in your result',
+    type: 'html',
+    sortable: true,
+    sortType: 'htmlNumber'
+  },
+  {
+    key: 'percentInResult',
+    name: 'Percent of bkgd Genes in your result',
+    helpText:
+      'Percentage of genes in the background in this pathway that are present in your result',
+    renderCell: decimalCellFactory(1)('percentInResult'),
+    sortable: true,
+    sortType: 'number'
+  },
+  {
+    key: 'foldEnrich',
+    name: 'Fold enrichment',
+    helpText:
+      'The percent of genes in this pathway in your result divided by the percent of genes in this pathway in the background',
+    renderCell: decimalCellFactory(2)('foldEnrich'),
+    sortable: true,
+    sortType: 'number'
+  },
+  {
+    key: 'oddsRatio',
+    name: 'Odds ratio',
+    helpText: "Odds ratio statistic from the Fisher's exact test",
+    renderCell: decimalCellFactory(2)('oddsRatio'),
+    sortable: true,
+    sortType: 'number'
+  },
+  {
+    key: 'pValue',
+    name: 'P-value',
+    helpText: "P-value from Fisher's exact test",
+    renderCell: scientificCellFactory(2)('pValue'),
+    sortable: true,
+    sortType: 'number'
+  },
+  {
+    key: 'benjamini',
+    name: 'Benjamini',
+    helpText: 'Benjamini-Hochberg false discovery rate (FDR)',
+    renderCell: scientificCellFactory(2)('benjamini'),
+    sortable: true,
+    sortType: 'number'
+  },
+  {
+    key: 'bonferroni',
+    name: 'Bonferroni',
+    helpText: 'Bonferroni adjusted p-value',
+    renderCell: scientificCellFactory(2)('bonferroni'),
+    sortable: true,
+    sortType: 'number'
+  }
+] as ColumnSettings[];
+
+const pathwayIdRenderFactory = (pathwayBaseUrl: string) => ({ row }: Record<string, any>) =>
+  <a href={`${pathwayBaseUrl}${row.pathwaySource}/${row.pathwayId}`} target="_blank">{row.pathwayId}</a>
+
+const pathwayButtonsConfigFactory = (
+  stepId: number,
+  analysisId: number,
+  { imageDownloadPath, hiddenDownloadPath }: any,
+  webAppUrl: string,
+  setWordCloudOpen: (wordCloudOpen: boolean) => void
+) => [
+    {
+      key: 'wordCloud',
+      onClick: (event: React.MouseEvent<HTMLAnchorElement>) => {
+        event.preventDefault();
+        setWordCloudOpen(true);
+      },
+      href: `${webAppUrl}/service/users/current/steps/${stepId}/analyses/${analysisId}/resources?path=${imageDownloadPath}`,
+      iconClassName: 'fa fa-bar-chart red-text',
+      contents: <Fragment>Show <b>Word Cloud</b></Fragment>
+    },
+    {
+      key: 'download',
+      href: `${webAppUrl}/service/users/current/steps/${stepId}/analyses/${analysisId}/resources?path=${hiddenDownloadPath}`,
+      iconClassName: 'fa fa-download blue-text',
+      contents: 'Download'
+    }
+  ];
+
+export const StepAnalysisPathwayEnrichmentResults: React.SFC<StepAnalysisResultPluginProps> = ({
+  analysisResult,
+  analysisConfig,
+  webAppUrl
+}) => {
+  const [wordCloudOpen, setWordCloudOpen] = useState(false);
+
+  return (
+    <Fragment>
+      <StepAnalysisButtonArray
+        configs={pathwayButtonsConfigFactory(
+          analysisConfig.stepId,
+          analysisConfig.analysisId,
+          analysisResult,
+          webAppUrl,
+          setWordCloudOpen
+        )}
+      />
+      <h3>Analysis Results:   </h3>
+      <CommonResultTable
+        emptyResultMessage={'No enrichment was found with significance at the P-value threshold you specified.'}
+        rows={analysisResult.resultData}
+        columns={pathwayEnrichmentResultColumns.map(column =>
+          column.key === 'pathwayId'
+            ? { ...column, renderCell: pathwayIdRenderFactory(analysisResult.pathwayBaseUrl) }
+            : column
+        )}
+        initialSortColumnKey={'oddsRatio'}
+        fixedTableHeader
+      />
+      <WordCloudModal
+        imgUrl={
+          `${webAppUrl}/service/users/current/steps/${analysisConfig.stepId}/analyses/${analysisConfig.analysisId}/resources?path=${analysisResult.imageDownloadPath}&_=${Date.now()}`
+        }
+        open={wordCloudOpen}
+        onClose={() => {
+          setWordCloudOpen(false);
+        }}
+        toolName={'Metabolic Pathway Enrichment Analysis'}
+      />
+    </Fragment>
+  );
+};

--- a/Site/webapp/wdkCustomization/js/client/components/stepAnalysis/StepAnalysisWordCloudModal.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/stepAnalysis/StepAnalysisWordCloudModal.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import { Dialog } from '@veupathdb/wdk-client/lib/Components';
+
+interface WordCloudModalProps {
+  imgUrl: string;
+  open: boolean;
+  onClose: () => void;
+  toolName: string;
+}
+
+export const WordCloudModal: React.SFC<WordCloudModalProps> = ({
+  imgUrl,
+  open,
+  onClose,
+  toolName,
+}) => (
+  <Dialog
+    open={open}
+    resizable
+    draggable
+    onClose={onClose}
+    title={`Word Cloud of ${toolName} Results`}
+    className="word-cloud-modal"
+  >
+    <img src={imgUrl} />
+    <p>
+      This word cloud was created using the P-values and the full terms from the Enrichment analysis via a program called GOSummaries
+    </p>
+    <p>
+      If you would like to download this image please <a href={imgUrl}>Click Here</a>
+    </p>
+  </Dialog>
+);

--- a/Site/webapp/wdkCustomization/js/client/components/stepAnalysis/StepAnalysisWordEnrichmentResults.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/stepAnalysis/StepAnalysisWordEnrichmentResults.tsx
@@ -1,0 +1,122 @@
+import React, { Fragment } from 'react';
+import { StepAnalysisResultPluginProps } from '@veupathdb/wdk-client/lib/Components/StepAnalysis/StepAnalysisResultsPane';
+import { integerCell, decimalCellFactory, scientificCellFactory } from '@veupathdb/wdk-client/lib/Components/StepAnalysis/Utils/StepAnalysisResults';
+import { CommonResultTable, ColumnSettings } from '@veupathdb/wdk-client/lib/Components/Shared/CommonResultTable';
+
+import './StepAnalysisEnrichmentResult.scss';
+import { StepAnalysisButtonArray } from '@veupathdb/wdk-client/lib/Components/StepAnalysis/StepAnalysisButtonArray';
+
+const wordEnrichmentResultColumns = [
+  { key: 'word', name: 'Word', helpText: 'Word', sortable: true },
+  {
+    key: 'descrip',
+    name: 'Description',
+    helpText: 'Description',
+    sortable: true
+  },
+  {
+    key: 'bgdGenes',
+    name: 'Genes in the bkgd with this word',
+    helpText: 'Number of genes with this word in the background',
+    renderCell: integerCell('bgdGenes'),
+    sortable: true,
+    sortType: 'number'
+  },
+  {
+    key: 'resultGenes',
+    name: 'Genes in your result with this word',
+    helpText: 'Number of genes with this word in your result',
+    renderCell: integerCell('resultGenes'),
+    sortable: true,
+    sortType: 'number'
+  },
+  {
+    key: 'percentInResult',
+    name: 'Percent of bkgd Genes in your result',
+    helpText:
+      'Of the genes in the background with this word, the percent that are present in your result',
+    renderCell: decimalCellFactory(1)('percentInResult'),
+    sortable: true,
+    sortType: 'number'
+  },
+  {
+    key: 'foldEnrich',
+    name: 'Fold enrichment',
+    helpText:
+      'The percent of genes with this word in your result divided by the percent of genes with this word in the background',
+    renderCell: decimalCellFactory(2)('foldEnrich'),
+    sortable: true,
+    sortType: 'number'
+  },
+  {
+    key: 'oddsRatio',
+    name: 'Odds ratio',
+    helpText: "Odds ratio statistic from the Fisher's exact test",
+    renderCell: decimalCellFactory(2)('oddsRatio'),
+    sortable: true,
+    sortType: 'number'
+  },
+  {
+    key: 'pValue',
+    name: 'P-value',
+    helpText: "P-value from Fisher's exact test",
+    renderCell: scientificCellFactory(2)('pValue'),
+    sortable: true,
+    sortType: 'number'
+  },
+  {
+    key: 'benjamini',
+    name: 'Benjamini',
+    helpText: 'Benjamini-Hochberg false discovery rate (FDR)',
+    renderCell: scientificCellFactory(2)('benjamini'),
+    sortable: true,
+    sortType: 'number'
+  },
+  {
+    key: 'bonferroni',
+    name: 'Bonferroni',
+    helpText: 'Bonferroni adjusted p-value',
+    renderCell: scientificCellFactory(2)('bonferroni'),
+    sortable: true,
+    sortType: 'number'
+  }
+] as ColumnSettings[];
+
+const wordEnrichmentButtonsConfigFactory = (
+  stepId: number,
+  analysisId: number,
+  { downloadPath }: any,
+  webAppUrl: string
+) => [
+    {
+      key: 'download',
+      href: `${webAppUrl}/service/users/current/steps/${stepId}/analyses/${analysisId}/resources?path=${downloadPath}`,
+      iconClassName: 'fa fa-download blue-text',
+      contents: 'Download'
+    }
+  ];
+
+export const StepAnalysisWordEnrichmentResults: React.SFC<StepAnalysisResultPluginProps> = ({
+  analysisResult,
+  analysisConfig,
+  webAppUrl
+}) => (
+  <Fragment>
+    <StepAnalysisButtonArray configs={
+      wordEnrichmentButtonsConfigFactory(
+        analysisConfig.stepId,
+        analysisConfig.analysisId,
+        analysisResult,
+        webAppUrl
+      )
+    } />
+    <h3>Analysis Results:   </h3>
+    <CommonResultTable
+      emptyResultMessage={'No enrichment was found with significance at the P-value threshold you specified.'}
+      rows={analysisResult.resultData}
+      columns={wordEnrichmentResultColumns}
+      initialSortColumnKey={'pValue'}
+      fixedTableHeader
+    />
+  </Fragment>
+);

--- a/Site/webapp/wdkCustomization/js/client/pluginConfig.tsx
+++ b/Site/webapp/wdkCustomization/js/client/pluginConfig.tsx
@@ -1,16 +1,12 @@
 import React, { Suspense } from 'react';
 
 import { Loading } from '@veupathdb/wdk-client/lib/Components';
-import { 
+import {
   GenomeSummaryViewPlugin,
   BlastSummaryViewPlugin,
   MatchedTranscriptsFilterPlugin,
   ResultTableSummaryViewPlugin,
-  StepAnalysisWordEnrichmentResults,
-  StepAnalysisPathwayEnrichmentResults,
-  StepAnalysisGoEnrichmentResults,
   StepAnalysisEupathExternalResult,
-  StepAnalysisHpiGeneListResults,
 } from '@veupathdb/wdk-client/lib/Plugins';
 import { ClientPluginRegistryEntry } from '@veupathdb/wdk-client/lib/Utils/ClientPlugin';
 
@@ -26,6 +22,10 @@ import { GenesByOrthologPattern } from './components/questions/GenesByOrthologPa
 import { InternalGeneDataset } from './components/questions/InternalGeneDataset';
 import { hasChromosomeAndSequenceIDXorGroup } from './components/questions/MutuallyExclusiveParams/utils';
 import { CompoundsByFoldChangeForm, GenericFoldChangeForm } from './components/questions/foldChange';
+import { StepAnalysisPathwayEnrichmentResults } from './components/stepAnalysis/StepAnalysisPathwayEnrichmentResults'
+import { StepAnalysisGoEnrichmentResults } from './components/stepAnalysis/StepAnalysisGoEnrichmentResults'
+import { StepAnalysisHpiGeneListResults } from './components/stepAnalysis/StepAnalysisHpiGeneListResults'
+import { StepAnalysisWordEnrichmentResults } from './components/stepAnalysis/StepAnalysisWordEnrichmentResults'
 
 import { isMultiBlastQuestion } from '@veupathdb/multi-blast/lib/utils/pluginConfig';
 
@@ -75,10 +75,10 @@ const apiPluginConfig: ClientPluginRegistryEntry<any>[] = [
   {
     type: 'summaryView',
     name: 'popset-view',
-    component: () => <div style={{margin: "2em", fontSize: "120%", fontWeight: "bold"}}>
-                       The Popset Isolate Sequences geographical map is not available since Google 
-                         has changed its Maps API products business model.<br/>
-                       We are working on a new and improved map for a future release.<br/>
+    component: () => <div style={{ margin: "2em", fontSize: "120%", fontWeight: "bold" }}>
+      The Popset Isolate Sequences geographical map is not available since Google
+                         has changed its Maps API products business model.<br />
+                       We are working on a new and improved map for a future release.<br />
                        Feel free to <a href='/a/app/contact-us'>contact us</a> with any comments and suggestions.
                      </div>
   },
@@ -101,7 +101,7 @@ const apiPluginConfig: ClientPluginRegistryEntry<any>[] = [
   {
     type: 'questionController',
     test: isMultiBlastQuestion,
-    component: (props) => 
+    component: (props) =>
       <Suspense fallback={<Loading />}>
         <BlastQuestionController {...props} />
       </Suspense>
@@ -161,7 +161,7 @@ const apiPluginConfig: ClientPluginRegistryEntry<any>[] = [
   },
   {
     type: 'questionForm',
-    test: ({ question }) => 
+    test: ({ question }) =>
       question?.urlSegment.endsWith('BySimilarity') ||
       question?.urlSegment === 'UnifiedBlast',
     component: BlastQuestionForm


### PR DESCRIPTION
This PR is connected to [this issue](https://github.com/VEuPathDB/WDKClient/issues/180) and [this PR](https://github.com/VEuPathDB/WDKClient/pull/189) in WDKClient.

The changes made are as follows:

- Moves these files from `WDKClient` to `ApiCommonWebsite`:
```
src/Core/MoveAfterRefactor/Components/StepAnalysis/StepAnalysisEnrichmentResult.scss
src/Core/MoveAfterRefactor/Components/StepAnalysis/StepAnalysisWordCloudModal.tsx
src/Core/MoveAfterRefactor/Components/StepAnalysis/StepAnalysisPathwayEnrichmentResults.tsx
src/Core/MoveAfterRefactor/Components/StepAnalysis/StepAnalysisGoEnrichmentResults.tsx
src/Core/MoveAfterRefactor/Components/StepAnalysis/StepAnalysisHpiGeneListResults.tsx
src/Core/MoveAfterRefactor/Components/StepAnalysis/StepAnalysisWordEnrichmentResults.tsx
```
- Updates references to these file changes as necessary

I was able to successfully run `wb site` with a bundled `wdk-client` via `npm-pack-here`. The built site succeeded in performing "Analyze Results" functionality without breaking.