### PR TITLE
Use @veupathdb/components Tooltip

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/components/genomeSummaryView/RegionDialog.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/genomeSummaryView/RegionDialog.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
 import { Dialog } from '@veupathdb/wdk-client/lib/Components';
-import { EagerlyLoadedTooltip } from '@veupathdb/wdk-client/lib/Components/Overlays/Tooltip';
 import { GenomeViewSequenceModel, GenomeViewRegionModel } from '../../util/GenomeSummaryViewUtils';
 import { FeatureTable } from './FeatureTable';
 import { FeatureTooltip } from './FeatureTooltip';
+import { Tooltip } from '@veupathdb/components/lib/components/widgets/Tooltip';
 
 interface RegionDialogProps {
   region: GenomeViewRegionModel;
@@ -38,9 +38,11 @@ export const RegionDialog: React.SFC<RegionDialogProps> = ({
         <div className="ruler">
           {
             region.features.map(feature =>
-              <EagerlyLoadedTooltip
+              <Tooltip
                 key={feature.sourceId}
-                content={
+                interactive
+                css={{}}
+                title={
                   <FeatureTooltip
                     feature={feature}
                     sequence={sequence}
@@ -57,7 +59,7 @@ export const RegionDialog: React.SFC<RegionDialogProps> = ({
                   }}
                 >
                 </div>      
-              </EagerlyLoadedTooltip>        
+              </Tooltip>        
             )
           }
         </div>

--- a/Site/webapp/wdkCustomization/js/client/components/genomeSummaryView/ResultsTable.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/genomeSummaryView/ResultsTable.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { defaultMemoize } from 'reselect';
 
-import { EagerlyLoadedTooltip } from '@veupathdb/wdk-client/lib/Components/Overlays/Tooltip';
 import { ColumnSettings, CommonResultTable } from '@veupathdb/wdk-client/lib/Components/Shared/CommonResultTable';
 import {
   GenomeSummaryViewReportModel,
@@ -11,6 +10,7 @@ import {
   GenomeViewSequenceModel
 } from '../../util/GenomeSummaryViewUtils';
 import { FeatureTooltip } from './FeatureTooltip';
+import { Tooltip } from '@veupathdb/components/lib/components/widgets/Tooltip';
 
 const resultColumnsFactory = defaultMemoize((
   displayName: string,
@@ -151,8 +151,10 @@ const SingleFeatureRegion: React.SFC<SingleFeatureRegionProps> = ({
   sequence,
   recordType,
 }) =>
-  <EagerlyLoadedTooltip
-    content={
+  <Tooltip
+    css={{}}
+    interactive
+    title={
       <FeatureTooltip
         feature={feature}
         sequence={sequence}
@@ -168,7 +170,7 @@ const SingleFeatureRegion: React.SFC<SingleFeatureRegionProps> = ({
       }}
     >
     </div>
-  </EagerlyLoadedTooltip>;
+  </Tooltip>;
 
 interface ResultsTableProps {
   emptyChromosomeFilterApplied: boolean;


### PR DESCRIPTION
Addresses https://redmine.apidb.org/issues/44503.

Note that the annoying, required `css` prop is come to my attention. See [this related issue](https://github.com/VEuPathDB/CoreUI/issues/79).