### PR TITLE
Incorporate @veupathdb/local-deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@
 
 # Dependencies
 node_modules/
+.yalc/
+yalc.lock
+.local-dependencies.json
 
 
 # Gradle meta

--- a/Site/.husky/pre-commit
+++ b/Site/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+cd Site/ && npx veupathdb-local-deps check

--- a/Site/.local-dependencies.sample.json
+++ b/Site/.local-dependencies.sample.json
@@ -1,0 +1,5 @@
+{
+  "localDependencies": {
+    "@veupathdb/web-common": "../../EbrcWebsiteCommon/Client"
+  }
+}

--- a/Site/package.json
+++ b/Site/package.json
@@ -5,6 +5,9 @@
   "license": "MIT",
   "scripts": {
     "start": "veupathdb-react-scripts run-site-dev-server --config webpack.config.local.mjs --port 3000",
+    "install-local-deps": "veupathdb-local-deps",
+    "uninstall-local-deps": "veupathdb-local-deps uninstall",
+    "watch-local-deps": "veupathdb-local-deps watch",
     "prepare": "cd .. && husky install Site/.husky"
   },
   "browserslist": [

--- a/Site/package.json
+++ b/Site/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "start": "veupathdb-react-scripts run-site-dev-server --config webpack.config.local.mjs --port 3000"
+    "start": "veupathdb-react-scripts run-site-dev-server --config webpack.config.local.mjs --port 3000",
+    "prepare": "cd .. && husky install Site/.husky"
   },
   "browserslist": [
     "extends @veupathdb/browserslist-config"
@@ -65,6 +66,7 @@
     "css-loader": "^2.1.1",
     "file-loader": "^3.0.1",
     "html-webpack-plugin": "^4.5.2",
+    "husky": "^8.0.0",
     "ify-loader": "^1.1.0",
     "jquery": "1.9.1",
     "mini-css-extract-plugin": "^0.6.0",

--- a/Site/yarn.lock
+++ b/Site/yarn.lock
@@ -6305,6 +6305,11 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
+husky@^8.0.0:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.1.tgz#511cb3e57de3e3190514ae49ed50f6bc3f50b3e9"
+  integrity sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==
+
 hyphenate-style-name@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz#691879af8e220aea5750e8827db4ef62a54e361d"


### PR DESCRIPTION
Depends on https://github.com/VEuPathDB/web-dev/pull/19

Can be tested by `npm-pack-here`ing the package from that PR into this repo.