### PR TITLE
Set page number to 1 on change to global view filter

### DIFF
--- a/Site/package.json
+++ b/Site/package.json
@@ -24,7 +24,7 @@
     "@veupathdb/preferred-organisms": "^1.1.11",
     "@veupathdb/study-data-access": "^0.3.5",
     "@veupathdb/user-datasets": "^0.1.8",
-    "@veupathdb/wdk-client": "^0.9.3",
+    "@veupathdb/wdk-client": "^0.9.5",
     "@veupathdb/web-common": "^0.6.17",
     "ciena-dagre": "^1.0.0",
     "core-js": "^3.21.1",

--- a/Site/webapp/wdkCustomization/js/client/util/transcriptFilters.js
+++ b/Site/webapp/wdkCustomization/js/client/util/transcriptFilters.js
@@ -18,11 +18,17 @@ export function isTranscripFilterEnabled(state, props) {
 
 // Add/remove representativeTranscriptOnly from global filters for record class
 export function requestTranscriptFilterUpdate(viewId, currentViewFilters, enable) {
-  return ResultTableSummaryViewActions.updateGlobalViewFilters(
-    viewId,
-    TRANSCRIPT_RECORD_CLASS_NAME,
-    updateTranscriptFilterValue(currentViewFilters, enable)
-  );
+  return [
+    ResultTableSummaryViewActions.updateGlobalViewFilters(
+      viewId,
+      TRANSCRIPT_RECORD_CLASS_NAME,
+      updateTranscriptFilterValue(currentViewFilters, enable)
+    ),
+    ResultTableSummaryViewActions.viewPageNumber(
+      viewId,
+      1
+    ),
+  ];
 }
 
 export function updateTranscriptFilterValue(currentViewFilters = [], enable) {

--- a/Site/yarn.lock
+++ b/Site/yarn.lock
@@ -2263,10 +2263,10 @@
     lodash "^4.17.21"
     moment "^2.21.0"
 
-"@veupathdb/wdk-client@^0.9.3":
-  version "0.9.3"
-  resolved "https://registry.yarnpkg.com/@veupathdb/wdk-client/-/wdk-client-0.9.3.tgz#dfc34b60fd4066ea7b12ba313c545d7f84f9eda3"
-  integrity sha512-dH+yzBp48w3Xy2SBXCOdqFbPKKXNkSndp4YPml1TNL8firk+hgbeb01aq8lyNi9R3hgFFp8yTvFaadDV7LJg/A==
+"@veupathdb/wdk-client@^0.9.5":
+  version "0.9.5"
+  resolved "https://registry.yarnpkg.com/@veupathdb/wdk-client/-/wdk-client-0.9.5.tgz#d46d5b05f903b0d84eecce78760abbac464e0441"
+  integrity sha512-UR6mBMy3thmxCDH1WkpO5f8Doh8JO1J7Ud0OEuZ9V5MSMjDhr9bM7Cbozzavmzrwt9i3HqXSv2LiYBqC+ipYOA==
   dependencies:
     classnames "^2.2.0"
     history "^4.10.1"


### PR DESCRIPTION
Along with [this change in WDKClient](https://github.com/VEuPathDB/WDKClient/pull/234), this resolves paging errors related to changes in the global view filter ([Redmine #48424](https://redmine.apidb.org/issues/48424)).