### PR TITLE
load molstar web component library asynchronously

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/main.js
+++ b/Site/webapp/wdkCustomization/js/client/main.js
@@ -1,3 +1,7 @@
 import { initialize } from './bootstrap';
 
 initialize();
+
+// Using dynamic import to lazy load these scripts
+import('../../../../vendored/pdbe-molstar-component-3.0.0');     
+import('../../../../vendored/pdbe-molstar-light-3.0.0.css');

--- a/Site/webpack.config.js
+++ b/Site/webpack.config.js
@@ -2,12 +2,7 @@ var configure = require('@veupathdb/site-webpack-config');
 
 const additionalConfig = {
   entry: {
-    'site-client': [
-      // suuport for <pdbe-molstar> custom element
-      './vendored/pdbe-molstar-light-3.0.0.css',
-      './vendored/pdbe-molstar-component-3.0.0',
-      __dirname + '/webapp/wdkCustomization/js/client/main.js',
-    ],
+    'site-client': __dirname + '/webapp/wdkCustomization/js/client/main.js',
   },
   resolve: {
     // alias 'ciena-*' entries to '/lib' directory since the default


### PR DESCRIPTION
This PR changes how the pdbe molstar web component files are loaded, so that they are loaded asynchronously. I know this is an unconventional way to do this, but it's currently the most ergonomic.