### PR TITLE
Fix responsiveness issue with JBrowse links

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/components/common/Gbrowse.jsx
+++ b/Site/webapp/wdkCustomization/js/client/components/common/Gbrowse.jsx
@@ -9,6 +9,14 @@ import newFeatureImage from '@veupathdb/wdk-client/lib/Core/Style/images/new-fea
 
 import './Gbrowse.scss';
 
+const JBrowseLinkContainerStyle = {
+  display: 'flex',
+  justifyContent: 'center',
+  flexWrap: 'wrap',
+  margin: '25px',
+  textAlign: 'center',
+};
+
 /**
  * Each entry below is used in two scenarios:
  *
@@ -117,19 +125,18 @@ export let contexts = [
 ];
 
 const JbrowseLink = ({ url }) =>
-    <div style={{ textAlign: 'center', margin: 25 }}>
+    <div style={JBrowseLinkContainerStyle}>
 <a href={url} className="eupathdb-BigButton" target="_blank">View in JBrowse genome browser</a>
 </div>
 
 const ApolloJbrowseLink = ({ url, urlApollo }) =>
-    <div style={{ textAlign: 'center', margin: 25 }}>
+    <div style={JBrowseLinkContainerStyle}>
 <a href={url} className="eupathdb-BigButton" target="_blank">View in JBrowse genome browser</a>
 <a href={urlApollo} className="eupathdb-BigButton" target="_blank">&emsp;&emsp;&emsp;&emsp;Annotate in Apollo&emsp;&emsp;&emsp;&emsp;</a>
 </div>
 
-
 const PbrowseJbrowseLink = ({ url }) =>
-    <div style={{ textAlign: 'center', margin: 25 }}>
+    <div style={JBrowseLinkContainerStyle}>
 <a href={url} className="eupathdb-BigButton">View in protein browser</a>
 </div>
 


### PR DESCRIPTION
Resolves [Redmine issue 48616](https://redmine.apidb.org/issues/48616).

Of note:
- Leveraged `display: flex` and `flex-wrap: wrap`
- Existing implementation adds 4 empty spaces to the beginning and the end of the Apollo link, presumably as a hack to get the two buttons to have similar widths. This raises the question:
  - Would we prefer a different approach that scales down better (see scaling issue in the last screenshot), or is this too much an edge case not to bother with?

![image](https://user-images.githubusercontent.com/69446567/188682794-eac0c46d-2527-4539-99cf-8540bfbc518b.png)

![image](https://user-images.githubusercontent.com/69446567/188682873-482519da-ad5d-4c35-8959-488b22986a4b.png)

![image](https://user-images.githubusercontent.com/69446567/188682941-c60f5f11-820e-44be-8910-9877740b73db.png)