### PR TITLE
Only include study-data-access modules if eda is enabled

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/bootstrap.js
+++ b/Site/webapp/wdkCustomization/js/client/bootstrap.js
@@ -1,5 +1,6 @@
 import { partial } from 'lodash';
 import { initialize as initializeEbrc } from '@veupathdb/web-common/lib/bootstrap';
+import { edaServiceUrl, useEda } from '@veupathdb/web-common/lib/config';
 // import apicomm wrappers and additional routes
 import * as componentWrappers from './componentWrappers';
 import { wrapRoutes } from './routes';
@@ -16,7 +17,6 @@ import '@veupathdb/web-common/lib/styles/client.scss';
 import '@veupathdb/preferred-organisms/lib/components/OrganismNode.scss';
 import 'site/css/AllApiSites.css';
 import 'site/wdkCustomization/css/client.scss';
-import { edaServiceUrl } from '@veupathdb/web-common/lib/config';
 
 // Initialize the application.
 export const initialize =  initializeWdk => initializeEbrc({
@@ -25,7 +25,7 @@ export const initialize =  initializeWdk => initializeEbrc({
   wrapRoutes,
   wrapStoreModules,
   wrapWdkService,
-  wrapWdkDependencies: partial(wrapWdkDependencies, edaServiceUrl),
+  wrapWdkDependencies: useEda ? partial(wrapWdkDependencies, edaServiceUrl) : undefined,
   pluginConfig,
-  additionalMiddleware: [ reduxMiddleware ],
+  additionalMiddleware: useEda ? [ reduxMiddleware ] : undefined,
 })


### PR DESCRIPTION
This is a partial fix for the issue of requesting dataset attributes that are not included in genomic sites. The fix is to only include the study-data-access modules if EDA is enabled for the website.

The fix is partial because there are still dataset attributes that need to be included for VectorBase. The full set of attributes requested can be seen in this POST data:

```
POST /record-types/dataset/searches/AllDatasets/reports/standard
Request Body: {
 "reportConfig": {
  "tables": [],
  "attributes": [
   "display_name",
   "dataset_id",
   "study_access",
   "email",
   "policy_url",
   "request_needs_approval",
   "bulk_download_url"
  ]
 },
 "searchConfig": {"parameters": {}}
}
```

A full fix will require either adding these attributes to the model, for projects using eda; or to only request these attributes if they exist in the model, using default values if they don't.