### PR TITLE
Make eda map link available in menu only if eda is enabled

### DIFF
--- a/Model/lib/conifer/roles/conifer/vars/ApiCommon/VectorBase.yml
+++ b/Model/lib/conifer/roles/conifer/vars/ApiCommon/VectorBase.yml
@@ -4,7 +4,7 @@ modelprop:
   TWITTER_URL_2: https://twitter.com/VectorBase
   FACEBOOK_URL: https://facebook.com/pages/VectorBase/189608142260
 eda:
-  enabled: "true"
+  enabled: "false"
   example_analyses_author: 854899613
   single_app_mode: pass
 user_datasets_workspace:

--- a/Model/lib/conifer/roles/conifer/vars/ApiCommon/VectorBase.yml
+++ b/Model/lib/conifer/roles/conifer/vars/ApiCommon/VectorBase.yml
@@ -4,7 +4,7 @@ modelprop:
   TWITTER_URL_2: https://twitter.com/VectorBase
   FACEBOOK_URL: https://facebook.com/pages/VectorBase/189608142260
 eda:
-  enabled: "false"
+  enabled: "true" # this will enable it for dev sites
   example_analyses_author: 854899613
   single_app_mode: pass
 user_datasets_workspace:

--- a/Model/lib/conifer/roles/conifer/vars/ApiCommon/production/VectorBase.yml
+++ b/Model/lib/conifer/roles/conifer/vars/ApiCommon/production/VectorBase.yml
@@ -1,10 +1,8 @@
 # $SourceFileURL$
 ---
 eda_enabled_env_map:
-  w_prefix: "false"
-  q_prefix: "false"
-  b_prefix: "true"
-  default: "true"
+  f_prefix: "true" # feature site
+  default: "false"
 eda:
   enabled: "{{ eda_enabled_env_map[prefix]|default(eda_enabled_env_map['default']) }}"
 

--- a/Model/lib/conifer/roles/conifer/vars/ApiCommon/production/VectorBase.yml
+++ b/Model/lib/conifer/roles/conifer/vars/ApiCommon/production/VectorBase.yml
@@ -1,6 +1,7 @@
 # $SourceFileURL$
 ---
 eda_enabled_env_map:
+  b_prefix: "true" # beta site
   f_prefix: "true" # feature site
   default: "false"
 eda:

--- a/Site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
@@ -28,7 +28,7 @@ import { Main } from '@veupathdb/web-common/lib/components/homepage/Main';
 import { NewsPane } from '@veupathdb/web-common/lib/components/homepage/NewsPane';
 import { SearchPane, SearchCheckboxTree } from '@veupathdb/web-common/lib/components/homepage/SearchPane';
 import { combineClassNames, useAlphabetizedSearchTree } from '@veupathdb/web-common/lib/components/homepage/Utils';
-import { useUserDatasetsWorkspace } from '@veupathdb/web-common/lib/config';
+import { useUserDatasetsWorkspace, useEda } from '@veupathdb/web-common/lib/config';
 import { useAnnouncementsState } from '@veupathdb/web-common/lib/hooks/announcements';
 import { useCommunitySiteRootUrl } from '@veupathdb/web-common/lib/hooks/staticData';
 import { STATIC_ROUTE_PATH } from '@veupathdb/web-common/lib/routes';
@@ -481,7 +481,7 @@ const useHeaderMenuItems = (
           type: 'reactRoute',
           url: '/workspace/analyses/studies',
           metadata: {
-            include: [ VectorBase ]
+            include: useEda ? [ VectorBase ] : []
          }
         },
         { 


### PR DESCRIPTION
This PR changes how we determine if the eda map link is available in the menu:
1. Only show the link if eda is enabled for the site
2. Only enable eda for feature.vectorbase.org