### PR TITLE
Check to ensure proper params before running cli tool

### DIFF
--- a/Service/src/main/java/org/apidb/apicommon/service/services/jbrowse/JBrowseService.java
+++ b/Service/src/main/java/org/apidb/apicommon/service/services/jbrowse/JBrowseService.java
@@ -24,6 +24,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import org.gusdb.wdk.model.WdkModelException;
+import org.gusdb.wdk.model.WdkRuntimeException;
 import org.gusdb.wdk.service.service.AbstractWdkService;
 import org.json.JSONObject;
 
@@ -371,6 +372,9 @@ public class JBrowseService extends AbstractWdkService {
     }
 
     public Response responseFromCommand(List<String> command) throws IOException {
+        for (int i = 0; i < command.size(); i++) {
+          if (command.get(i) == null) throw new WdkRuntimeException("Command part at index " + i + " is null.  Could be due to unchecked user input.");
+        }
         ProcessBuilder pb = new ProcessBuilder(command);
         Map<String, String> env = pb.environment();
         env.put("GUS_HOME", getWdkModel().getGusHome());

--- a/Service/src/main/java/org/apidb/apicommon/service/services/jbrowse/JBrowseService.java
+++ b/Service/src/main/java/org/apidb/apicommon/service/services/jbrowse/JBrowseService.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
@@ -314,13 +315,17 @@ public class JBrowseService extends AbstractWdkService {
     @Produces(MediaType.APPLICATION_JSON)
     public Response getJbrowseNames(@PathParam("organismAbbrev") String organismAbbrev, @QueryParam("equals") String eq, @QueryParam("startswith") String startsWith)  throws IOException {
 
+        if ((startsWith == null || startsWith.isBlank()) && (eq == null || eq.isBlank())) {
+          throw new BadRequestException("Request must include one of the following query parameters: ['startswith', 'equals']");
+        }
+
         String gusHome = getWdkModel().getGusHome();
         String projectId = getWdkModel().getProjectId();
 
         boolean isPartial = true;
         String sourceId = startsWith;
 
-        if(eq != null && !eq.equals("")) {
+        if (eq != null && !eq.isBlank()) {
             isPartial = false;
             sourceId = eq;
         }

--- a/Service/src/main/java/org/apidb/apicommon/service/services/jbrowse/JBrowseService.java
+++ b/Service/src/main/java/org/apidb/apicommon/service/services/jbrowse/JBrowseService.java
@@ -373,7 +373,9 @@ public class JBrowseService extends AbstractWdkService {
 
     public Response responseFromCommand(List<String> command) throws IOException {
         for (int i = 0; i < command.size(); i++) {
-          if (command.get(i) == null) throw new WdkRuntimeException("Command part at index " + i + " is null.  Could be due to unchecked user input.");
+          if (command.get(i) == null)
+            throw new WdkRuntimeException(
+                "Command part at index " + i + " is null.  Could be due to unchecked user input.");
         }
         ProcessBuilder pb = new ProcessBuilder(command);
         Map<String, String> env = pb.environment();


### PR DESCRIPTION
@bgajria or @jbrestel you guys should probably add similar checks to these methods and throw BadRequestException (HTTP 400 status).  Doing so will prevent @aurreco-uga from getting error emails when spammers hit these endpoints.

I replaced the NullPointerExceptions we were getting with WdkRuntimeException but it will still trigger a 500 + an error email.