### PR TITLE
Use standard Content-Type response header

### DIFF
--- a/Model/src/main/java/org/apidb/apicommon/model/report/bed/BedReporter.java
+++ b/Model/src/main/java/org/apidb/apicommon/model/report/bed/BedReporter.java
@@ -80,7 +80,7 @@ public abstract class BedReporter extends AbstractReporter {
 
   @Override
   public String getHttpContentType() {
-    return "text/x-bed";
+    return "text/plain";
   }
 
   @Override

--- a/Model/src/main/java/org/apidb/apicommon/model/report/sequence/SequenceReporter.java
+++ b/Model/src/main/java/org/apidb/apicommon/model/report/sequence/SequenceReporter.java
@@ -35,7 +35,7 @@ public class SequenceReporter extends AbstractReporter {
 
   private static Logger LOG = Logger.getLogger(SequenceReporter.class);
 
-  private static final String FASTA_MEDIA_TYPE = "text/x-fasta";
+  private static final String FASTA_MEDIA_TYPE = "text/plain";
   private static final String BED_REPORTER_NAME = "bed";
 
   private enum SequenceType {


### PR DESCRIPTION
fixes #177 

This PR uses standard `Content-Type` response header values. This makes `Content-Disposition: inline` work as expected in Firefox.

This can be tested on https://dfalke-b.plasmodb.org.