### PR TITLE
Refactor pseudo-polymorphic bare string and iff-laden code to sealed union and enums

### DIFF
--- a/Model/src/main/java/org/apidb/apicommon/model/comment/pojo/AiProvenanceView.java
+++ b/Model/src/main/java/org/apidb/apicommon/model/comment/pojo/AiProvenanceView.java
@@ -18,64 +18,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class AiProvenanceView {
 
-  /**
-   * The article source of the AI run, mirroring the client's discriminated
-   * union: {@code {kind:'pubmed', pubmedId}} or {@code {kind:'upload',
-   * externalUrl?, externalTitle?, pdfContentSha256?}}. NON_NULL inclusion drops
-   * the fields that don't apply to the active {@code kind}; {@code pdfContentSha256}
-   * lets the client match an uploaded PDF to an existing published comment, the
-   * upload-path analogue of matching a PubMed comment by its PMID.
-   */
-  @JsonInclude(JsonInclude.Include.NON_NULL)
-  public static class Source {
-
-    private final String _kind;
-    private final String _pubmedId;
-    private final String _externalUrl;
-    private final String _externalTitle;
-    private final String _pdfContentSha256;
-    private final String _externalRef;
-    private final String _externalRefKind;
-
-    private Source(String kind, String pubmedId, String externalUrl,
-        String externalTitle, String pdfContentSha256,
-        String externalRef, String externalRefKind) {
-      _kind = kind;
-      _pubmedId = pubmedId;
-      _externalUrl = externalUrl;
-      _externalTitle = externalTitle;
-      _pdfContentSha256 = pdfContentSha256;
-      _externalRef = externalRef;
-      _externalRefKind = externalRefKind;
-    }
-
-    /** A PubMed-sourced run, identified by its PMID alone. */
-    public static Source pubmed(String pubmedId) {
-      return new Source("pubmed", pubmedId, null, null, null, null, null);
-    }
-
-    /** An upload-sourced run; url/title and an asserted PMID/DOI ref all optional. */
-    public static Source upload(String externalUrl, String externalTitle,
-        String pdfContentSha256, String externalRef, String externalRefKind) {
-      return new Source("upload", null, externalUrl, externalTitle, pdfContentSha256,
-          externalRef, externalRefKind);
-    }
-
-    public String getKind() { return _kind; }
-    public String getPubmedId() { return _pubmedId; }
-    public String getExternalUrl() { return _externalUrl; }
-    public String getExternalTitle() { return _externalTitle; }
-    public String getPdfContentSha256() { return _pdfContentSha256; }
-    public String getExternalRef() { return _externalRef; }
-    public String getExternalRefKind() { return _externalRefKind; }
-  }
-
   private final boolean _edited;
-  private final Source _source;
+  private final AiRunSource _source;
   private final String _originalHeadline;
   private final String _originalContent;
 
-  public AiProvenanceView(boolean edited, Source source,
+  public AiProvenanceView(boolean edited, AiRunSource source,
       String originalHeadline, String originalContent) {
     _edited = edited;
     _source = source;
@@ -86,7 +34,17 @@ public class AiProvenanceView {
   @JsonProperty("isEdited")
   public boolean isEdited() { return _edited; }
 
-  public Source getSource() { return _source; }
+  /**
+   * The article source of the AI run, the shared {@link AiRunSource} union
+   * serialized as the client's discriminated union: {@code {kind:'pubmed',
+   * pubmedId}} or {@code {kind:'upload', pdfContentSha256, externalUrl?,
+   * externalTitle?, externalRef?, externalRefKind?}}. The record shape plus its
+   * NON_NULL inclusion drop the fields that don't apply to the active
+   * {@code kind}; {@code pdfContentSha256} lets the client match an uploaded PDF
+   * to an existing published comment, the upload-path analogue of matching a
+   * PubMed comment by its PMID.
+   */
+  public AiRunSource getSource() { return _source; }
 
   public String getOriginalHeadline() { return _originalHeadline; }
 

--- a/Model/src/main/java/org/apidb/apicommon/model/comment/pojo/AiRunSource.java
+++ b/Model/src/main/java/org/apidb/apicommon/model/comment/pojo/AiRunSource.java
@@ -1,0 +1,45 @@
+package org.apidb.apicommon.model.comment.pojo;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * The article source of a {@link CommentAiRun}, as a sealed discriminated union
+ * replacing the former flat {@code source_kind} string plus its "valid-iff-kind"
+ * fields. One value type is shared by every source carrier — the cache row
+ * ({@link CommentAiRun}), the in-flight submission, and the read-side
+ * {@link AiProvenanceView} — so the pubmed-vs-upload branch is written once, as an
+ * exhaustive {@code switch}, instead of duplicated {@code "pubmed".equals(...)}
+ * checks.
+ *
+ * <p>The union serializes as the client's discriminated union without Jackson
+ * polymorphism: each record carries only its own fields, and {@link #kind()} is
+ * the {@code kind} discriminator. Read-side JSON ({@link AiProvenanceView}) is
+ * camelCase via Jackson; the AI job endpoints build the snake_case shape by hand.
+ */
+public sealed interface AiRunSource permits AiRunSource.Pubmed, AiRunSource.Upload {
+
+  /** The source discriminator ({@code pubmed} | {@code upload}). */
+  SourceKind kind();
+
+  /** A PubMed-sourced run, identified by its PMID alone. */
+  record Pubmed(String pubmedId) implements AiRunSource {
+    @Override
+    @JsonProperty("kind")
+    public SourceKind kind() { return SourceKind.PUBMED; }
+  }
+
+  /**
+   * An upload-sourced run; the {@code externalUrl}/{@code externalTitle} and the
+   * asserted PMID/DOI {@code externalRef}/{@code externalRefKind} are all optional.
+   * {@code @JsonInclude(NON_NULL)} drops the absent optionals so the serialized
+   * shape matches the read-side client union.
+   */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  record Upload(String pdfContentSha256, String externalUrl, String externalTitle,
+                String externalRef, ExternalRefKind externalRefKind) implements AiRunSource {
+    @Override
+    @JsonProperty("kind")
+    public SourceKind kind() { return SourceKind.UPLOAD; }
+  }
+}

--- a/Model/src/main/java/org/apidb/apicommon/model/comment/pojo/CommentAiRun.java
+++ b/Model/src/main/java/org/apidb/apicommon/model/comment/pojo/CommentAiRun.java
@@ -21,17 +21,11 @@ public class CommentAiRun {
   private String _jobId;                 // hex SHA-256, primary key
   private String _modelName;
   private String _promptVersion;
-  private String _sourceKind;            // 'pubmed' | 'upload'
-  private String _pubmedId;              // iff sourceKind == 'pubmed'
-  private String _externalUrl;           // iff sourceKind == 'upload', optional
-  private String _externalTitle;         // iff sourceKind == 'upload', optional
-  private String _pdfContentSha256;      // iff sourceKind == 'upload'
-  private String _externalRef;           // iff sourceKind == 'upload', optional (PMID/DOI)
-  private String _externalRefKind;       // 'pubmed' | 'doi' | null
+  private AiRunSource _source;           // pubmed or upload, a sealed union
   private String _geneId;
   private final List<String> _synonymsUsed = new ArrayList<>();
   private String _optionsJson;           // canonical JSON of request `options`
-  private String _terminalStatus;
+  private JobStatus _terminalStatus;     // one of the three publishable terminals
   private boolean _onlyMentionedInPassing;
   private String _aiHeadline;            // null unless terminalStatus == 'success'
   private String _aiContent;             // null unless terminalStatus == 'success'
@@ -46,26 +40,8 @@ public class CommentAiRun {
   public String getPromptVersion() { return _promptVersion; }
   public CommentAiRun setPromptVersion(String promptVersion) { _promptVersion = promptVersion; return this; }
 
-  public String getSourceKind() { return _sourceKind; }
-  public CommentAiRun setSourceKind(String sourceKind) { _sourceKind = sourceKind; return this; }
-
-  public String getPubmedId() { return _pubmedId; }
-  public CommentAiRun setPubmedId(String pubmedId) { _pubmedId = pubmedId; return this; }
-
-  public String getExternalUrl() { return _externalUrl; }
-  public CommentAiRun setExternalUrl(String externalUrl) { _externalUrl = externalUrl; return this; }
-
-  public String getExternalTitle() { return _externalTitle; }
-  public CommentAiRun setExternalTitle(String externalTitle) { _externalTitle = externalTitle; return this; }
-
-  public String getExternalRef() { return _externalRef; }
-  public CommentAiRun setExternalRef(String externalRef) { _externalRef = externalRef; return this; }
-
-  public String getExternalRefKind() { return _externalRefKind; }
-  public CommentAiRun setExternalRefKind(String externalRefKind) { _externalRefKind = externalRefKind; return this; }
-
-  public String getPdfContentSha256() { return _pdfContentSha256; }
-  public CommentAiRun setPdfContentSha256(String pdfContentSha256) { _pdfContentSha256 = pdfContentSha256; return this; }
+  public AiRunSource getSource() { return _source; }
+  public CommentAiRun setSource(AiRunSource source) { _source = source; return this; }
 
   public String getGeneId() { return _geneId; }
   public CommentAiRun setGeneId(String geneId) { _geneId = geneId; return this; }
@@ -80,8 +56,8 @@ public class CommentAiRun {
   public String getOptionsJson() { return _optionsJson; }
   public CommentAiRun setOptionsJson(String optionsJson) { _optionsJson = optionsJson; return this; }
 
-  public String getTerminalStatus() { return _terminalStatus; }
-  public CommentAiRun setTerminalStatus(String terminalStatus) { _terminalStatus = terminalStatus; return this; }
+  public JobStatus getTerminalStatus() { return _terminalStatus; }
+  public CommentAiRun setTerminalStatus(JobStatus terminalStatus) { _terminalStatus = terminalStatus; return this; }
 
   public boolean isOnlyMentionedInPassing() { return _onlyMentionedInPassing; }
   public CommentAiRun setOnlyMentionedInPassing(boolean v) { _onlyMentionedInPassing = v; return this; }

--- a/Model/src/main/java/org/apidb/apicommon/model/comment/pojo/ExternalRefKind.java
+++ b/Model/src/main/java/org/apidb/apicommon/model/comment/pojo/ExternalRefKind.java
@@ -1,0 +1,39 @@
+package org.apidb.apicommon.model.comment.pojo;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Kind of the optional upload-path external reference — a PubMed id or a DOI.
+ * Nullable everywhere it appears (null = "no external ref"); serialized to/from
+ * the wire (request/response {@code external_ref_kind}) and the
+ * {@code comment_ai_run.external_ref_kind} column as its lowercase
+ * {@link #getWireValue()}.
+ */
+public enum ExternalRefKind {
+
+  PUBMED("pubmed"),
+  DOI("doi");
+
+  private final String _wire;
+
+  ExternalRefKind(String wire) { _wire = wire; }
+
+  /** The lowercase value used on the wire and in the {@code external_ref_kind} column. */
+  @JsonValue
+  public String getWireValue() { return _wire; }
+
+  /**
+   * Parse a wire/DB value, leniently: unknown or null input returns {@code null}
+   * rather than throwing, so {@code ExternalRef.normalise} can emit its documented
+   * 400 ("external_ref_kind must be 'pubmed' or 'doi'") instead of a Jackson error.
+   */
+  @JsonCreator
+  public static ExternalRefKind fromWire(String wire) {
+    if (wire == null) return null;
+    String trimmed = wire.trim();
+    for (ExternalRefKind k : values())
+      if (k._wire.equals(trimmed)) return k;
+    return null;
+  }
+}

--- a/Model/src/main/java/org/apidb/apicommon/model/comment/pojo/JobStatus.java
+++ b/Model/src/main/java/org/apidb/apicommon/model/comment/pojo/JobStatus.java
@@ -1,10 +1,14 @@
-package org.apidb.apicommon.service.services.ai;
+package org.apidb.apicommon.model.comment.pojo;
 
 /**
  * The {@code type} discriminator on a status response, matching the front-end
  * contract union (see {@code CLAUDE-ai-user-comments.md}). {@link #RUNNING} is
- * the only non-terminal value; while running, the {@link JobState.Stage} carries
- * the finer-grained progress.
+ * the only non-terminal value; while running, the finer-grained progress stage
+ * is carried separately.
+ *
+ * <p>Lives in the Model layer because the three publishable terminals are
+ * persisted to {@code comment_ai_run.terminal_status} and typed onto
+ * {@link CommentAiRun}; the Service layer shares this same enum.
  */
 public enum JobStatus {
 
@@ -28,8 +32,15 @@ public enum JobStatus {
     _terminal = terminal;
   }
 
-  /** The snake/kebab-case value sent on the wire. */
+  /** The snake/kebab-case value sent on the wire and stored in {@code terminal_status}. */
   public String getWireValue() { return _wire; }
+
+  /** Reverse of {@link #getWireValue()}, for reading a persisted {@code terminal_status}. */
+  public static JobStatus fromWireValue(String wire) {
+    for (JobStatus s : values())
+      if (s._wire.equals(wire)) return s;
+    throw new IllegalArgumentException("unknown JobStatus wire value: " + wire);
+  }
 
   public boolean isTerminal() { return _terminal; }
 

--- a/Model/src/main/java/org/apidb/apicommon/model/comment/pojo/SourceKind.java
+++ b/Model/src/main/java/org/apidb/apicommon/model/comment/pojo/SourceKind.java
@@ -1,0 +1,38 @@
+package org.apidb.apicommon.model.comment.pojo;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * The article source of an AI gene-publication run: a PubMed lookup or a
+ * client-side PDF upload. Serialized to/from the wire (request
+ * {@code document_type}, response {@code source.kind}) and the
+ * {@code comment_ai_run.source_kind} column as its lowercase {@link #getWireValue()}.
+ */
+public enum SourceKind {
+
+  PUBMED("pubmed"),
+  UPLOAD("upload");
+
+  private final String _wire;
+
+  SourceKind(String wire) { _wire = wire; }
+
+  /** The lowercase value used on the wire and in the {@code source_kind} column. */
+  @JsonValue
+  public String getWireValue() { return _wire; }
+
+  /**
+   * Parse a wire/DB value, leniently: unknown or null input returns {@code null}
+   * rather than throwing, so request validation can emit the documented 400
+   * ("document_type must be 'pubmed' or 'upload'") instead of a Jackson error.
+   */
+  @JsonCreator
+  public static SourceKind fromWire(String wire) {
+    if (wire == null) return null;
+    String trimmed = wire.trim();
+    for (SourceKind k : values())
+      if (k._wire.equals(trimmed)) return k;
+    return null;
+  }
+}

--- a/Model/src/main/java/org/apidb/apicommon/model/comment/repo/AiRunSourceRows.java
+++ b/Model/src/main/java/org/apidb/apicommon/model/comment/repo/AiRunSourceRows.java
@@ -1,0 +1,31 @@
+package org.apidb.apicommon.model.comment.repo;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.apidb.apicommon.model.comment.pojo.AiRunSource;
+import org.apidb.apicommon.model.comment.pojo.ExternalRefKind;
+import org.apidb.apicommon.model.comment.pojo.SourceKind;
+
+/**
+ * Maps the {@code source_kind}/{@code pubmed_id}/{@code external_*}/
+ * {@code pdf_content_sha256} columns of a {@code comment_ai_run} row (or a join
+ * onto it) into the sealed {@link AiRunSource} union. Shared by the two read
+ * queries so the pubmed-vs-upload branch is written once.
+ */
+final class AiRunSourceRows {
+
+  private AiRunSourceRows() {}
+
+  /** Build the source union from the current row's source columns. */
+  static AiRunSource fromResultSet(ResultSet rs) throws SQLException {
+    return SourceKind.PUBMED == SourceKind.fromWire(rs.getString("source_kind"))
+        ? new AiRunSource.Pubmed(rs.getString("pubmed_id"))
+        : new AiRunSource.Upload(
+            rs.getString("pdf_content_sha256"),
+            rs.getString("external_url"),
+            rs.getString("external_title"),
+            rs.getString("external_ref"),
+            ExternalRefKind.fromWire(rs.getString("external_ref_kind")));
+  }
+}

--- a/Model/src/main/java/org/apidb/apicommon/model/comment/repo/GetCommentAiProvenanceQuery.java
+++ b/Model/src/main/java/org/apidb/apicommon/model/comment/repo/GetCommentAiProvenanceQuery.java
@@ -54,18 +54,9 @@ public class GetCommentAiProvenanceQuery extends ValueQuery<Map<Long, AiProvenan
     while (rs.next()) {
       long commentId = rs.getLong("comment_id");
 
-      AiProvenanceView.Source source = "pubmed".equals(rs.getString("source_kind"))
-          ? AiProvenanceView.Source.pubmed(rs.getString("pubmed_id"))
-          : AiProvenanceView.Source.upload(
-              rs.getString("external_url"),
-              rs.getString("external_title"),
-              rs.getString("pdf_content_sha256"),
-              rs.getString("external_ref"),
-              rs.getString("external_ref_kind"));
-
       out.put(commentId, new AiProvenanceView(
           rs.getBoolean("is_edited"),
-          source,
+          AiRunSourceRows.fromResultSet(rs),
           nullToEmpty(rs.getString("ai_headline")),
           nullToEmpty(rs.getString("ai_content"))));
     }

--- a/Model/src/main/java/org/apidb/apicommon/model/comment/repo/GetCommentAiRunQuery.java
+++ b/Model/src/main/java/org/apidb/apicommon/model/comment/repo/GetCommentAiRunQuery.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apidb.apicommon.model.comment.pojo.CommentAiRun;
+import org.apidb.apicommon.model.comment.pojo.JobStatus;
 
 /**
  * Look up a single {@code comment_ai_run} row by its content-digest
@@ -53,21 +54,15 @@ public class GetCommentAiRunQuery extends ValueQuery<Optional<CommentAiRun>> {
         .setJobId(rs.getString("job_id"))
         .setModelName(rs.getString("model_name"))
         .setPromptVersion(rs.getString("prompt_version"))
-        .setSourceKind(rs.getString("source_kind"))
-        .setPubmedId(rs.getString("pubmed_id"))
-        .setExternalUrl(rs.getString("external_url"))
-        .setExternalTitle(rs.getString("external_title"))
-        .setPdfContentSha256(rs.getString("pdf_content_sha256"))
+        .setSource(AiRunSourceRows.fromResultSet(rs))
         .setGeneId(rs.getString("gene_id"))
         .setSynonymsUsed(toStringList(rs.getArray("synonyms_used")))
         .setOptionsJson(rs.getString("options_json"))
-        .setTerminalStatus(rs.getString("terminal_status"))
+        .setTerminalStatus(JobStatus.fromWireValue(rs.getString("terminal_status")))
         .setOnlyMentionedInPassing(rs.getBoolean("is_only_mentioned_in_passing"))
         .setAiHeadline(rs.getString("ai_headline"))
         .setAiContent(rs.getString("ai_content"))
-        .setCompletedAt(rs.getTimestamp("completed_at"))
-        .setExternalRef(rs.getString("external_ref"))
-        .setExternalRefKind(rs.getString("external_ref_kind"));
+        .setCompletedAt(rs.getTimestamp("completed_at"));
 
     return Optional.of(run);
   }

--- a/Model/src/main/java/org/apidb/apicommon/model/comment/repo/InsertCommentAiRunQuery.java
+++ b/Model/src/main/java/org/apidb/apicommon/model/comment/repo/InsertCommentAiRunQuery.java
@@ -10,6 +10,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 
+import org.apidb.apicommon.model.comment.pojo.AiRunSource;
 import org.apidb.apicommon.model.comment.pojo.CommentAiRun;
 import org.gusdb.fgputil.db.runner.ArgumentBatch;
 import org.gusdb.fgputil.db.runner.ListArgumentBatch;
@@ -78,15 +79,31 @@ public class InsertCommentAiRunQuery extends InsertQuery {
     Timestamp completedAt = _run.getCompletedAt() == null ? null
         : new Timestamp(_run.getCompletedAt().getTime());
 
+    // Flatten the sealed source union onto the flat column set: each kind fills
+    // its own columns and leaves the others null.
+    String sourceKind = _run.getSource().kind().getWireValue();
+    String pubmedId = null, externalUrl = null, externalTitle = null,
+        pdfContentSha256 = null, externalRef = null, externalRefKind = null;
+    switch (_run.getSource()) {
+      case AiRunSource.Pubmed p -> pubmedId = p.pubmedId();
+      case AiRunSource.Upload u -> {
+        pdfContentSha256 = u.pdfContentSha256();
+        externalUrl = u.externalUrl();
+        externalTitle = u.externalTitle();
+        externalRef = u.externalRef();
+        externalRefKind = u.externalRefKind() == null ? null : u.externalRefKind().getWireValue();
+      }
+    }
+
     ListArgumentBatch batch = new ListArgumentBatch();
     batch.add(new Object[] {
         _run.getJobId(), _run.getModelName(), _run.getPromptVersion(),
-        _run.getSourceKind(), _run.getPubmedId(), _run.getExternalUrl(),
-        _run.getExternalTitle(), _run.getPdfContentSha256(), _run.getGeneId(),
-        synonyms, _run.getOptionsJson(), _run.getTerminalStatus(),
+        sourceKind, pubmedId, externalUrl,
+        externalTitle, pdfContentSha256, _run.getGeneId(),
+        synonyms, _run.getOptionsJson(), _run.getTerminalStatus().getWireValue(),
         _run.isOnlyMentionedInPassing(), _run.getAiHeadline(),
         _run.getAiContent(), completedAt,
-        _run.getExternalRef(), _run.getExternalRefKind()
+        externalRef, externalRefKind
     });
     batch.setParameterTypes(TYPES);
     return batch;

--- a/Service/src/main/java/org/apidb/apicommon/service/services/ai/AiGenePublicationCommentService.java
+++ b/Service/src/main/java/org/apidb/apicommon/service/services/ai/AiGenePublicationCommentService.java
@@ -17,8 +17,10 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.apidb.apicommon.model.comment.pojo.AiProvenance;
+import org.apidb.apicommon.model.comment.pojo.AiRunSource;
 import org.apidb.apicommon.model.comment.pojo.CommentAiRun;
 import org.apidb.apicommon.model.comment.pojo.CommentRequest;
+import org.apidb.apicommon.model.comment.pojo.JobStatus;
 import org.apidb.apicommon.model.comment.pojo.Target;
 import org.apidb.apicommon.service.services.ai.SyncPrelude.PreludeResult;
 import org.apidb.apicommon.service.services.ai.gene.GeneSynonymService;
@@ -71,7 +73,7 @@ public class AiGenePublicationCommentService extends AbstractUserCommentService 
           .header("Retry-After", RETRY_AFTER_SECONDS)
           .type(MediaType.APPLICATION_JSON)
           .entity(new JSONObject()
-              .put("type", "internal-error")
+              .put("type", JobStatus.INTERNAL_ERROR.getWireValue())
               .put("error", "summary workers are busy; please retry shortly")
               .toString())
           .build();
@@ -217,7 +219,7 @@ public class AiGenePublicationCommentService extends AbstractUserCommentService 
           .put("type", JobStatus.RUNNING.getWireValue())
           .put("job_id", job.getJobId())
           .put("stage", job.getStage().getWireValue())
-          .put("source", sourceJson(job.getSubmission()));
+          .put("source", sourceJson(job.getSubmission().getSource()));
     }
     // Terminal: the pipeline publishes a TerminalResult carrying the status-
     // specific fields (text-unavailable `reason`, internal-error `error`,
@@ -227,7 +229,7 @@ public class AiGenePublicationCommentService extends AbstractUserCommentService 
     if (job.getResult() instanceof TerminalResult) {
       JSONObject out = ((TerminalResult) job.getResult()).toJson(job.getJobId());
       if (job.getStatus().isPublishable())
-        out.put("source", sourceJson(job.getSubmission()));
+        out.put("source", sourceJson(job.getSubmission().getSource()));
       return out;
     }
     return new JSONObject()
@@ -240,16 +242,16 @@ public class AiGenePublicationCommentService extends AbstractUserCommentService 
     // (only publishable terminals are persisted), so a cache hit always carries a
     // source. No comment_id — the comment is created only on publish.
     JSONObject out = new JSONObject()
-        .put("type", run.getTerminalStatus())
+        .put("type", run.getTerminalStatus().getWireValue())
         .put("job_id", jobId);
-    if ("success".equals(run.getTerminalStatus())) {
+    if (run.getTerminalStatus() == JobStatus.SUCCESS) {
       out.put("ai_output", new JSONObject()
           .put("headline", run.getAiHeadline())
           .put("content", run.getAiContent()));
     } else {
       out.put("synonyms_checked", new JSONArray(run.getSynonymsUsed()));
     }
-    out.put("source", sourceJson(run));
+    out.put("source", sourceJson(run.getSource()));
     return out;
   }
 
@@ -266,33 +268,23 @@ public class AiGenePublicationCommentService extends AbstractUserCommentService 
    * cached {@link CommentAiRun} row on a late cache hit — both carry the same
    * source fields by construction.
    */
-  static JSONObject sourceJson(JobSubmission s) {
-    return sourceJson(s.getSourceKind(), s.getPubmedId(), s.getPdfContentSha256(),
-        s.getExternalUrl(), s.getExternalTitle(), s.getExternalRef(), s.getExternalRefKind());
-  }
-
-  static JSONObject sourceJson(CommentAiRun run) {
-    return sourceJson(run.getSourceKind(), run.getPubmedId(), run.getPdfContentSha256(),
-        run.getExternalUrl(), run.getExternalTitle(), run.getExternalRef(), run.getExternalRefKind());
-  }
-
-  private static JSONObject sourceJson(String kind, String pubmedId, String pdfContentSha256,
-      String externalUrl, String externalTitle, String externalRef, String externalRefKind) {
-    JSONObject source = new JSONObject().put("kind", kind);
-    if ("pubmed".equals(kind)) {
-      source.put("pubmed_id", pubmedId);
-    }
-    else {
-      source.put("pdf_content_sha256", pdfContentSha256);
-      // url/title/ref are optional upload provenance — omit when absent, mirroring
-      // the NON_NULL behaviour of aiProvenance.source.
-      if (externalUrl != null) source.put("external_url", externalUrl);
-      if (externalTitle != null) source.put("external_title", externalTitle);
-      if (externalRef != null) {
-        source.put("external_ref", externalRef);
-        source.put("external_ref_kind", externalRefKind);
+  static JSONObject sourceJson(AiRunSource source) {
+    JSONObject json = new JSONObject().put("kind", source.kind().getWireValue());
+    switch (source) {
+      case AiRunSource.Pubmed p -> json.put("pubmed_id", p.pubmedId());
+      case AiRunSource.Upload u -> {
+        json.put("pdf_content_sha256", u.pdfContentSha256());
+        // url/title/ref are optional upload provenance — omit when absent, mirroring
+        // the NON_NULL behaviour of aiProvenance.source.
+        if (u.externalUrl() != null) json.put("external_url", u.externalUrl());
+        if (u.externalTitle() != null) json.put("external_title", u.externalTitle());
+        if (u.externalRef() != null) {
+          json.put("external_ref", u.externalRef());
+          if (u.externalRefKind() != null)
+            json.put("external_ref_kind", u.externalRefKind().getWireValue());
+        }
       }
     }
-    return source;
+    return json;
   }
 }

--- a/Service/src/main/java/org/apidb/apicommon/service/services/ai/AiGenePublicationPipeline.java
+++ b/Service/src/main/java/org/apidb/apicommon/service/services/ai/AiGenePublicationPipeline.java
@@ -7,7 +7,9 @@ import java.util.List;
 import java.util.Map;
 
 import org.apidb.apicommon.controller.CommentFactoryManager;
+import org.apidb.apicommon.model.comment.pojo.AiRunSource;
 import org.apidb.apicommon.model.comment.pojo.CommentAiRun;
+import org.apidb.apicommon.model.comment.pojo.JobStatus;
 import org.apidb.apicommon.service.services.ai.article.PmcBiocFetcher;
 import org.apidb.apicommon.service.services.ai.article.PmcBiocFetcher.TextUnavailableException;
 import org.apidb.apicommon.service.services.ai.gene.GeneMentionScanner;
@@ -161,20 +163,21 @@ public class AiGenePublicationPipeline implements Runnable {
     _job.updateStage(JobState.Stage.FETCHING_ARTICLE, "Resolving article text");
     JobSubmission submission = _job.getSubmission();
 
-    // Upload path: the front-end already extracted the text (MuPDF.js); nothing
-    // to fetch. The stage is still emitted for symmetry but completes at once.
-    if ("upload".equals(submission.getSourceKind())) {
-      _articleText = submission.getUploadedPaperText();
-      return;
-    }
+    switch (submission.getSource()) {
+      // Upload path: the front-end already extracted the text (MuPDF.js); nothing
+      // to fetch. The stage is still emitted for symmetry but completes at once.
+      case AiRunSource.Upload u -> _articleText = submission.getUploadedPaperText();
 
-    // PubMed path: fetch and parse the PMC BioC document.
-    try {
-      _articleText = _fetcher.fetch(submission.getPubmedId());
-    }
-    catch (TextUnavailableException e) {
-      _job.markTerminal(JobStatus.TEXT_UNAVAILABLE,
-          TerminalResult.textUnavailable(e.getMessage()));
+      // PubMed path: fetch and parse the PMC BioC document.
+      case AiRunSource.Pubmed p -> {
+        try {
+          _articleText = _fetcher.fetch(p.pubmedId());
+        }
+        catch (TextUnavailableException e) {
+          _job.markTerminal(JobStatus.TEXT_UNAVAILABLE,
+              TerminalResult.textUnavailable(e.getMessage()));
+        }
+      }
     }
   }
 
@@ -446,17 +449,11 @@ public class AiGenePublicationPipeline implements Runnable {
         .setJobId(s.getJobId())
         .setModelName(s.getModelName())
         .setPromptVersion(s.getPromptVersion())
-        .setSourceKind(s.getSourceKind())
-        .setPubmedId(s.getPubmedId())
-        .setExternalUrl(s.getExternalUrl())
-        .setExternalTitle(s.getExternalTitle())
-        .setPdfContentSha256(s.getPdfContentSha256())
-        .setExternalRef(s.getExternalRef())
-        .setExternalRefKind(s.getExternalRefKind())
+        .setSource(s.getSource())
         .setGeneId(s.getGeneId())
         .setSynonymsUsed(s.getSynonyms())
         .setOptionsJson(s.getOptionsJson())
-        .setTerminalStatus(terminal.getWireValue())
+        .setTerminalStatus(terminal)
         .setOnlyMentionedInPassing(terminal == JobStatus.MENTIONED_IN_PASSING)
         .setAiHeadline(success ? _aiHeadline : null)
         .setAiContent(success ? _aiContent : null)

--- a/Service/src/main/java/org/apidb/apicommon/service/services/ai/AiGenePublicationRequest.java
+++ b/Service/src/main/java/org/apidb/apicommon/service/services/ai/AiGenePublicationRequest.java
@@ -1,5 +1,8 @@
 package org.apidb.apicommon.service.services.ai;
 
+import org.apidb.apicommon.model.comment.pojo.ExternalRefKind;
+import org.apidb.apicommon.model.comment.pojo.SourceKind;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -38,9 +41,9 @@ public class AiGenePublicationRequest {
   @JsonProperty("gene_id")
   public String geneId;
 
-  /** {@code pubmed} | {@code upload}. */
+  /** {@code pubmed} | {@code upload}. Null when absent or unrecognised (→ 400 in validation). */
   @JsonProperty("document_type")
-  public String documentType;
+  public SourceKind documentType;
 
   /** iff document_type == pubmed. */
   @JsonProperty("pubmed_id")
@@ -68,7 +71,7 @@ public class AiGenePublicationRequest {
 
   /** {@code pubmed} | {@code doi} — kind of {@link #externalRef}; upload path only. */
   @JsonProperty("external_ref_kind")
-  public String externalRefKind;
+  public ExternalRefKind externalRefKind;
 
   @JsonProperty("options")
   public Options options = new Options();

--- a/Service/src/main/java/org/apidb/apicommon/service/services/ai/ExternalRef.java
+++ b/Service/src/main/java/org/apidb/apicommon/service/services/ai/ExternalRef.java
@@ -4,6 +4,8 @@ import java.util.regex.Pattern;
 
 import javax.ws.rs.BadRequestException;
 
+import org.apidb.apicommon.model.comment.pojo.ExternalRefKind;
+
 /**
  * Normalises and validates the optional upload-path external reference
  * (a PubMed id or a DOI). Store-and-display only: never enters the job_id
@@ -11,9 +13,6 @@ import javax.ws.rs.BadRequestException;
  * so the same rules drive both the FE auto-detection and this server-side check.
  */
 public final class ExternalRef {
-
-  public static final String KIND_PUBMED = "pubmed";
-  public static final String KIND_DOI = "doi";
 
   private static final Pattern PMID = Pattern.compile("^\\d{1,9}$");
   private static final Pattern DOI = Pattern.compile("^10\\.\\d{4,9}/\\S+$");
@@ -25,9 +24,9 @@ public final class ExternalRef {
   /** Normalised (ref, kind); either both set or both null. */
   public static final class Result {
     public final String ref;
-    public final String kind;
+    public final ExternalRefKind kind;
 
-    Result(String ref, String kind) {
+    Result(String ref, ExternalRefKind kind) {
       this.ref = ref;
       this.kind = kind;
     }
@@ -35,29 +34,32 @@ public final class ExternalRef {
 
   private ExternalRef() {}
 
-  public static Result normalise(String rawRef, String rawKind) {
+  public static Result normalise(String rawRef, ExternalRefKind kind) {
     if (rawRef == null || rawRef.trim().isEmpty()) {
       return new Result(null, null); // blank ref → no provenance, kind ignored
     }
-    String kind = rawKind == null ? "" : rawKind.trim();
     String ref = rawRef.trim();
 
+    if (kind == null)
+      throw new BadRequestException(
+          "external_ref_kind must be 'pubmed' or 'doi' when external_ref is present");
+
     switch (kind) {
-      case KIND_PUBMED: {
+      case PUBMED -> {
         String stripped = PMID_PREFIX.matcher(ref).replaceFirst("").trim();
         if (!PMID.matcher(stripped).matches())
           throw new BadRequestException(
               "external_ref is not a valid PubMed id: " + rawRef);
-        return new Result(stripped, KIND_PUBMED);
+        return new Result(stripped, ExternalRefKind.PUBMED);
       }
-      case KIND_DOI: {
+      case DOI -> {
         String stripped = DOI_URL_PREFIX.matcher(ref).replaceFirst("").trim();
         if (!DOI.matcher(stripped).matches())
           throw new BadRequestException(
               "external_ref is not a valid DOI: " + rawRef);
-        return new Result(stripped, KIND_DOI);
+        return new Result(stripped, ExternalRefKind.DOI);
       }
-      default:
+      default ->
         throw new BadRequestException(
             "external_ref_kind must be 'pubmed' or 'doi' when external_ref is present");
     }

--- a/Service/src/main/java/org/apidb/apicommon/service/services/ai/JobRegistry.java
+++ b/Service/src/main/java/org/apidb/apicommon/service/services/ai/JobRegistry.java
@@ -5,6 +5,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+
+import org.apidb.apicommon.model.comment.pojo.JobStatus;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;

--- a/Service/src/main/java/org/apidb/apicommon/service/services/ai/JobState.java
+++ b/Service/src/main/java/org/apidb/apicommon/service/services/ai/JobState.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Future;
 
+import org.apidb.apicommon.model.comment.pojo.JobStatus;
+
 /**
  * Mutable in-memory state for one AI gene-publication job, keyed in
  * {@link JobRegistry} by the content-digest {@code jobId} (not a UUID).

--- a/Service/src/main/java/org/apidb/apicommon/service/services/ai/JobSubmission.java
+++ b/Service/src/main/java/org/apidb/apicommon/service/services/ai/JobSubmission.java
@@ -4,6 +4,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.apidb.apicommon.model.comment.pojo.AiRunSource;
+import org.apidb.apicommon.model.comment.pojo.SourceKind;
+
 /**
  * Immutable bundle of the resolved inputs for one job, produced by the
  * {@link SyncPrelude} and carried on {@link JobState} for the pipeline to read.
@@ -14,8 +17,11 @@ import java.util.List;
  * Follower-specific state (the user id, and the {@code comment_id} each follower
  * receives at persist time) lives on {@link JobState}, not here.
  *
- * <p>Note on {@code paperText}: for the upload path the FE-supplied text is a
- * submission input ({@link #getUploadedPaperText()}); for the pubmed path the
+ * <p>The article {@link #getSource()} is the persisted source provenance (the
+ * same {@link AiRunSource} union stored on {@link org.apidb.apicommon.model.comment.pojo.CommentAiRun}).
+ * Note on {@code uploadedPaperText}: for the upload path the FE-supplied text is a
+ * submission input ({@link #getUploadedPaperText()}) but is <em>not</em> part of
+ * the source union — it is transient (never persisted). For the pubmed path the
  * text is fetched in pipeline stage ① and is therefore a transient pipeline
  * intermediate, not part of this immutable submission.
  */
@@ -24,14 +30,8 @@ public final class JobSubmission {
   private final String _jobId;
   private final String _geneId;
   private final List<String> _synonyms;        // sorted, canonical
-  private final String _sourceKind;            // 'pubmed' | 'upload'
-  private final String _pubmedId;              // iff sourceKind == 'pubmed'
-  private final String _pdfContentSha256;      // iff sourceKind == 'upload'
-  private final String _uploadedPaperText;     // iff sourceKind == 'upload' (FE-extracted)
-  private final String _externalUrl;           // optional upload provenance
-  private final String _externalTitle;         // optional upload provenance
-  private final String _externalRef;           // optional upload provenance (PMID/DOI)
-  private final String _externalRefKind;       // 'pubmed' | 'doi' | null
+  private final AiRunSource _source;           // persisted source provenance
+  private final String _uploadedPaperText;     // iff upload (FE-extracted); transient, not persisted
   private final AiGenePublicationRequest.Options _options;
   private final String _optionsJson;           // canonical JSON of _options (baked into jobId)
   private final String _modelName;
@@ -51,14 +51,11 @@ public final class JobSubmission {
     _jobId = jobId;
     _geneId = request.geneId;
     _synonyms = Collections.unmodifiableList(new ArrayList<>(synonyms));
-    _sourceKind = request.documentType;
-    _pubmedId = request.pubmedId;
-    _pdfContentSha256 = request.pdfContentSha256;
+    _source = request.documentType == SourceKind.PUBMED
+        ? new AiRunSource.Pubmed(request.pubmedId)
+        : new AiRunSource.Upload(request.pdfContentSha256, request.externalUrl,
+            request.externalTitle, request.externalRef, request.externalRefKind);
     _uploadedPaperText = request.paperText;
-    _externalUrl = request.externalUrl;
-    _externalTitle = request.externalTitle;
-    _externalRef = request.externalRef;
-    _externalRefKind = request.externalRefKind;
     _options = request.options;
     _optionsJson = optionsJson;
     _modelName = modelName;
@@ -68,14 +65,8 @@ public final class JobSubmission {
   public String getJobId() { return _jobId; }
   public String getGeneId() { return _geneId; }
   public List<String> getSynonyms() { return _synonyms; }
-  public String getSourceKind() { return _sourceKind; }
-  public String getPubmedId() { return _pubmedId; }
-  public String getPdfContentSha256() { return _pdfContentSha256; }
+  public AiRunSource getSource() { return _source; }
   public String getUploadedPaperText() { return _uploadedPaperText; }
-  public String getExternalUrl() { return _externalUrl; }
-  public String getExternalTitle() { return _externalTitle; }
-  public String getExternalRef() { return _externalRef; }
-  public String getExternalRefKind() { return _externalRefKind; }
   public AiGenePublicationRequest.Options getOptions() { return _options; }
   public String getOptionsJson() { return _optionsJson; }
   public String getModelName() { return _modelName; }

--- a/Service/src/main/java/org/apidb/apicommon/service/services/ai/SyncPrelude.java
+++ b/Service/src/main/java/org/apidb/apicommon/service/services/ai/SyncPrelude.java
@@ -8,6 +8,7 @@ import javax.ws.rs.BadRequestException;
 
 import org.apidb.apicommon.model.comment.CommentFactory;
 import org.apidb.apicommon.model.comment.pojo.CommentAiRun;
+import org.apidb.apicommon.model.comment.pojo.SourceKind;
 import org.apidb.apicommon.service.services.ai.gene.GeneSynonymService;
 import org.gusdb.wdk.model.WdkModel;
 import org.gusdb.wdk.model.WdkModelException;
@@ -48,16 +49,17 @@ public class SyncPrelude {
     if (isBlank(request.geneId))
       throw new BadRequestException("gene_id is required");
 
-    String type = request.documentType == null ? "" : request.documentType.trim();
-    switch (type) {
-      case "pubmed":
+    if (request.documentType == null)
+      throw new BadRequestException("document_type must be 'pubmed' or 'upload'");
+    switch (request.documentType) {
+      case PUBMED -> {
         if (isBlank(request.pubmedId))
           throw new BadRequestException("pubmed_id is required when document_type=pubmed");
         // external_ref is an upload-only field; never carry it on the pubmed path.
         request.externalRef = null;
         request.externalRefKind = null;
-        break;
-      case "upload":
+      }
+      case UPLOAD -> {
         if (isBlank(request.paperText))
           throw new BadRequestException("paper_text is required when document_type=upload");
         if (request.pdfContentSha256 == null
@@ -67,9 +69,7 @@ public class SyncPrelude {
         ExternalRef.Result ref = ExternalRef.normalise(request.externalRef, request.externalRefKind);
         request.externalRef = ref.ref;
         request.externalRefKind = ref.kind;
-        break;
-      default:
-        throw new BadRequestException("document_type must be 'pubmed' or 'upload'");
+      }
     }
   }
 
@@ -98,7 +98,7 @@ public class SyncPrelude {
   }
 
   private static String sourceKey(AiGenePublicationRequest request) {
-    return "upload".equals(request.documentType)
+    return request.documentType == SourceKind.UPLOAD
         ? request.pdfContentSha256
         : request.pubmedId;
   }

--- a/Service/src/main/java/org/apidb/apicommon/service/services/ai/TerminalResult.java
+++ b/Service/src/main/java/org/apidb/apicommon/service/services/ai/TerminalResult.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.apidb.apicommon.model.comment.pojo.JobStatus;
 import org.json.JSONArray;
 import org.json.JSONObject;
 

--- a/Service/src/test/java/org/apidb/apicommon/service/services/ai/AiGenePublicationPipelineTest.java
+++ b/Service/src/test/java/org/apidb/apicommon/service/services/ai/AiGenePublicationPipelineTest.java
@@ -13,6 +13,8 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apidb.apicommon.model.comment.pojo.CommentAiRun;
+import org.apidb.apicommon.model.comment.pojo.JobStatus;
+import org.apidb.apicommon.model.comment.pojo.SourceKind;
 import org.apidb.apicommon.service.services.ai.article.PmcBiocFetcher;
 import org.apidb.apicommon.service.services.ai.article.PmcBiocFetcher.TextUnavailableException;
 import org.apidb.apicommon.service.services.ai.gene.GeneMentionScanner;
@@ -41,7 +43,7 @@ public class AiGenePublicationPipelineTest {
       List<String> synonyms) {
     AiGenePublicationRequest r = new AiGenePublicationRequest();
     r.geneId = "PF3D7_1133400";
-    r.documentType = documentType;
+    r.documentType = SourceKind.fromWire(documentType);
     r.pubmedId = pubmedId;
     r.paperText = paperText;
     JobSubmission submission = new JobSubmission(
@@ -353,8 +355,8 @@ public class AiGenePublicationPipelineTest {
     CommentAiRun row = store.captured;
     assertNotNull(row);
     assertEquals("deadbeef", row.getJobId());
-    assertEquals("success", row.getTerminalStatus());
-    assertEquals("upload", row.getSourceKind());
+    assertEquals(JobStatus.SUCCESS, row.getTerminalStatus());
+    assertEquals(SourceKind.UPLOAD, row.getSource().kind());
     assertEquals("claude-sonnet-4", row.getModelName());
     assertEquals("1", row.getPromptVersion());
     assertEquals("{}", row.getOptionsJson());
@@ -432,7 +434,7 @@ public class AiGenePublicationPipelineTest {
     assertEquals(JobStatus.GENE_NOT_MENTIONED, pipeline.job().getStatus());
     assertEquals("gene-not-mentioned is persisted to the cache", 1, store.calls);
     CommentAiRun row = store.captured;
-    assertEquals("gene-not-mentioned", row.getTerminalStatus());
+    assertEquals(JobStatus.GENE_NOT_MENTIONED, row.getTerminalStatus());
     assertNull(row.getAiHeadline());
     assertNull(row.getAiContent());
     assertFalse(row.isOnlyMentionedInPassing());
@@ -451,7 +453,7 @@ public class AiGenePublicationPipelineTest {
     assertEquals(JobStatus.MENTIONED_IN_PASSING, pipeline.job().getStatus());
     assertEquals("mentioned-in-passing is persisted to the cache", 1, store.calls);
     CommentAiRun row = store.captured;
-    assertEquals("mentioned-in-passing", row.getTerminalStatus());
+    assertEquals(JobStatus.MENTIONED_IN_PASSING, row.getTerminalStatus());
     assertTrue(row.isOnlyMentionedInPassing());
     assertNull(row.getAiHeadline());
   }

--- a/Service/src/test/java/org/apidb/apicommon/service/services/ai/AiGenePublicationPublishTest.java
+++ b/Service/src/test/java/org/apidb/apicommon/service/services/ai/AiGenePublicationPublishTest.java
@@ -8,8 +8,10 @@ import static org.junit.Assert.assertTrue;
 import java.util.Date;
 
 import org.apidb.apicommon.model.comment.pojo.AiProvenance;
+import org.apidb.apicommon.model.comment.pojo.AiRunSource;
 import org.apidb.apicommon.model.comment.pojo.CommentAiRun;
 import org.apidb.apicommon.model.comment.pojo.CommentRequest;
+import org.apidb.apicommon.model.comment.pojo.JobStatus;
 import org.apidb.apicommon.service.services.ai.gene.GeneSynonymService;
 import org.json.JSONObject;
 import org.junit.Test;
@@ -27,7 +29,7 @@ public class AiGenePublicationPublishTest {
     return new CommentAiRun()
         .setJobId("deadbeef")
         .setGeneId("PF3D7_1133400")
-        .setTerminalStatus("success")
+        .setTerminalStatus(JobStatus.SUCCESS)
         .setAiHeadline("Pfs25 matters.")
         .setAiContent("- A finding.");
   }
@@ -77,7 +79,7 @@ public class AiGenePublicationPublishTest {
     CommentAiRun run = new CommentAiRun()
         .setJobId("cafe")
         .setGeneId("PF3D7_0100100")
-        .setTerminalStatus("gene-not-mentioned");
+        .setTerminalStatus(JobStatus.GENE_NOT_MENTIONED);
     CommentRequest req = AiGenePublicationCommentService.buildPublishComment(
         run, "My own headline", "My own observations.", new Date(), null);
     assertTrue("user-written body over a null AI original → edited",
@@ -103,8 +105,8 @@ public class AiGenePublicationPublishTest {
 
   @Test
   public void sourceJsonPubmedRunHasKindAndPmidOnly() {
-    CommentAiRun run = new CommentAiRun().setSourceKind("pubmed").setPubmedId("39324028");
-    JSONObject json = AiGenePublicationCommentService.sourceJson(run);
+    CommentAiRun run = new CommentAiRun().setSource(new AiRunSource.Pubmed("39324028"));
+    JSONObject json = AiGenePublicationCommentService.sourceJson(run.getSource());
 
     assertEquals("pubmed", json.getString("kind"));
     assertEquals("39324028", json.getString("pubmed_id"));
@@ -114,12 +116,9 @@ public class AiGenePublicationPublishTest {
 
   @Test
   public void sourceJsonUploadRunHasDigestAndOptionalProvenance() {
-    CommentAiRun run = new CommentAiRun()
-        .setSourceKind("upload")
-        .setPdfContentSha256("abcd1234")
-        .setExternalUrl("http://x/paper.pdf")
-        .setExternalTitle("A Paper");
-    JSONObject json = AiGenePublicationCommentService.sourceJson(run);
+    CommentAiRun run = new CommentAiRun().setSource(
+        new AiRunSource.Upload("abcd1234", "http://x/paper.pdf", "A Paper", null, null));
+    JSONObject json = AiGenePublicationCommentService.sourceJson(run.getSource());
 
     assertEquals("upload", json.getString("kind"));
     assertEquals("abcd1234", json.getString("pdf_content_sha256"));
@@ -130,8 +129,9 @@ public class AiGenePublicationPublishTest {
 
   @Test
   public void sourceJsonUploadOmitsNullUrlAndTitle() {
-    CommentAiRun run = new CommentAiRun().setSourceKind("upload").setPdfContentSha256("abcd1234");
-    JSONObject json = AiGenePublicationCommentService.sourceJson(run);
+    CommentAiRun run = new CommentAiRun().setSource(
+        new AiRunSource.Upload("abcd1234", null, null, null, null));
+    JSONObject json = AiGenePublicationCommentService.sourceJson(run.getSource());
 
     assertEquals("upload", json.getString("kind"));
     assertEquals("abcd1234", json.getString("pdf_content_sha256"));

--- a/Service/src/test/java/org/apidb/apicommon/service/services/ai/AiProvenanceFromRunTest.java
+++ b/Service/src/test/java/org/apidb/apicommon/service/services/ai/AiProvenanceFromRunTest.java
@@ -8,6 +8,7 @@ import java.util.Date;
 
 import org.apidb.apicommon.model.comment.pojo.AiProvenance;
 import org.apidb.apicommon.model.comment.pojo.CommentAiRun;
+import org.apidb.apicommon.model.comment.pojo.JobStatus;
 import org.junit.Test;
 
 /**
@@ -24,7 +25,7 @@ public class AiProvenanceFromRunTest {
     return new CommentAiRun()
         .setJobId("deadbeef")
         .setGeneId("PF3D7_1133400")
-        .setTerminalStatus("success")
+        .setTerminalStatus(JobStatus.SUCCESS)
         .setAiHeadline("Pfs25 matters.")
         .setAiContent("- A finding.");
   }

--- a/Service/src/test/java/org/apidb/apicommon/service/services/ai/AiProvenanceViewTest.java
+++ b/Service/src/test/java/org/apidb/apicommon/service/services/ai/AiProvenanceViewTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.apidb.apicommon.model.comment.pojo.AiProvenanceView;
+import org.apidb.apicommon.model.comment.pojo.AiRunSource;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -27,7 +28,7 @@ public class AiProvenanceViewTest {
   @Test
   public void pubmedSourceSerializesPmidOnly() {
     JsonNode json = tree(new AiProvenanceView(
-        false, AiProvenanceView.Source.pubmed("12345"), "Headline", "Content"));
+        false, new AiRunSource.Pubmed("12345"), "Headline", "Content"));
 
     assertFalse(json.get("isEdited").asBoolean());
     assertEquals("Headline", json.get("originalHeadline").asText());
@@ -44,7 +45,7 @@ public class AiProvenanceViewTest {
   public void uploadSourceSerializesAllPresentFields() {
     JsonNode json = tree(new AiProvenanceView(
         true,
-        AiProvenanceView.Source.upload("http://x/paper.pdf", "A Paper", "abcd1234", null, null),
+        new AiRunSource.Upload("abcd1234", "http://x/paper.pdf", "A Paper", null, null),
         "H", "C"));
 
     assertTrue(json.get("isEdited").asBoolean());
@@ -60,7 +61,7 @@ public class AiProvenanceViewTest {
   @Test
   public void uploadSourceOmitsNullUrlAndTitleButKeepsDigest() {
     JsonNode json = tree(new AiProvenanceView(
-        false, AiProvenanceView.Source.upload(null, null, "abcd1234", null, null), "H", "C"));
+        false, new AiRunSource.Upload("abcd1234", null, null, null, null), "H", "C"));
 
     JsonNode source = json.get("source");
     assertEquals("upload", source.get("kind").asText());

--- a/Service/src/test/java/org/apidb/apicommon/service/services/ai/ExternalRefTest.java
+++ b/Service/src/test/java/org/apidb/apicommon/service/services/ai/ExternalRefTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertNull;
 
 import javax.ws.rs.BadRequestException;
 
+import org.apidb.apicommon.model.comment.pojo.ExternalRefKind;
 import org.junit.Test;
 
 public class ExternalRefTest {
@@ -18,54 +19,54 @@ public class ExternalRefTest {
 
   @Test
   public void blankRef_ignoresKind() {
-    ExternalRef.Result r = ExternalRef.normalise("   ", "pubmed");
+    ExternalRef.Result r = ExternalRef.normalise("   ", ExternalRefKind.PUBMED);
     assertNull(r.ref);
     assertNull(r.kind);
   }
 
   @Test
   public void pubmed_plainDigits() {
-    ExternalRef.Result r = ExternalRef.normalise("12345678", "pubmed");
+    ExternalRef.Result r = ExternalRef.normalise("12345678", ExternalRefKind.PUBMED);
     assertEquals("12345678", r.ref);
-    assertEquals("pubmed", r.kind);
+    assertEquals(ExternalRefKind.PUBMED, r.kind);
   }
 
   @Test
   public void pubmed_stripsPrefixAndWhitespace() {
-    ExternalRef.Result r = ExternalRef.normalise("  PMID: 12345678 ", "pubmed");
+    ExternalRef.Result r = ExternalRef.normalise("  PMID: 12345678 ", ExternalRefKind.PUBMED);
     assertEquals("12345678", r.ref);
-    assertEquals("pubmed", r.kind);
+    assertEquals(ExternalRefKind.PUBMED, r.kind);
   }
 
   @Test(expected = BadRequestException.class)
   public void pubmed_rejectsNonDigits() {
-    ExternalRef.normalise("abc123", "pubmed");
+    ExternalRef.normalise("abc123", ExternalRefKind.PUBMED);
   }
 
   @Test
   public void doi_plain() {
-    ExternalRef.Result r = ExternalRef.normalise("10.1234/abc.def", "doi");
+    ExternalRef.Result r = ExternalRef.normalise("10.1234/abc.def", ExternalRefKind.DOI);
     assertEquals("10.1234/abc.def", r.ref);
-    assertEquals("doi", r.kind);
+    assertEquals(ExternalRefKind.DOI, r.kind);
   }
 
   @Test
   public void doi_stripsUrlPrefix() {
-    ExternalRef.Result r = ExternalRef.normalise("https://doi.org/10.1234/abc.def", "doi");
+    ExternalRef.Result r = ExternalRef.normalise("https://doi.org/10.1234/abc.def", ExternalRefKind.DOI);
     assertEquals("10.1234/abc.def", r.ref);
-    assertEquals("doi", r.kind);
+    assertEquals(ExternalRefKind.DOI, r.kind);
   }
 
   @Test
   public void doi_stripsDxUrlPrefix() {
-    ExternalRef.Result r = ExternalRef.normalise("https://dx.doi.org/10.1234/abc.def", "doi");
+    ExternalRef.Result r = ExternalRef.normalise("https://dx.doi.org/10.1234/abc.def", ExternalRefKind.DOI);
     assertEquals("10.1234/abc.def", r.ref);
-    assertEquals("doi", r.kind);
+    assertEquals(ExternalRefKind.DOI, r.kind);
   }
 
   @Test(expected = BadRequestException.class)
   public void doi_rejectsNonDoi() {
-    ExternalRef.normalise("not-a-doi", "doi");
+    ExternalRef.normalise("not-a-doi", ExternalRefKind.DOI);
   }
 
   @Test(expected = BadRequestException.class)
@@ -75,11 +76,13 @@ public class ExternalRefTest {
 
   @Test(expected = BadRequestException.class)
   public void refPresent_rejectsUnknownKind() {
-    ExternalRef.normalise("12345678", "isbn");
+    // an unrecognised external_ref_kind parses leniently to null, which a
+    // present ref rejects the same way a missing kind does.
+    ExternalRef.normalise("12345678", ExternalRefKind.fromWire("isbn"));
   }
 
   @Test(expected = BadRequestException.class)
   public void kindMismatch_pubmedKindWithDoiValue() {
-    ExternalRef.normalise("10.1234/abc", "pubmed");
+    ExternalRef.normalise("10.1234/abc", ExternalRefKind.PUBMED);
   }
 }

--- a/Service/src/test/java/org/apidb/apicommon/service/services/ai/JobRegistryTest.java
+++ b/Service/src/test/java/org/apidb/apicommon/service/services/ai/JobRegistryTest.java
@@ -20,6 +20,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
+import org.apidb.apicommon.model.comment.pojo.JobStatus;
+import org.apidb.apicommon.model.comment.pojo.SourceKind;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -46,7 +48,7 @@ public class JobRegistryTest {
   private static JobSubmission submission(String jobId) {
     AiGenePublicationRequest r = new AiGenePublicationRequest();
     r.geneId = "PF3D7_1133400";
-    r.documentType = "pubmed";
+    r.documentType = SourceKind.PUBMED;
     r.pubmedId = "12345678";
     return new JobSubmission(r, jobId, Collections.emptyList(),
         "claude-sonnet-4-20250514", "getGeneSummary/v1", "{}");

--- a/Service/src/test/java/org/apidb/apicommon/service/services/ai/SyncPreludeTest.java
+++ b/Service/src/test/java/org/apidb/apicommon/service/services/ai/SyncPreludeTest.java
@@ -2,6 +2,8 @@ package org.apidb.apicommon.service.services.ai;
 
 import javax.ws.rs.BadRequestException;
 
+import org.apidb.apicommon.model.comment.pojo.ExternalRefKind;
+import org.apidb.apicommon.model.comment.pojo.SourceKind;
 import org.junit.Test;
 
 public class SyncPreludeTest {
@@ -9,7 +11,7 @@ public class SyncPreludeTest {
   private static AiGenePublicationRequest pubmedRequest() {
     AiGenePublicationRequest r = new AiGenePublicationRequest();
     r.geneId = "PF3D7_1133400";
-    r.documentType = "pubmed";
+    r.documentType = SourceKind.PUBMED;
     r.pubmedId = "12345678";
     return r;
   }
@@ -17,7 +19,7 @@ public class SyncPreludeTest {
   private static AiGenePublicationRequest uploadRequest() {
     AiGenePublicationRequest r = new AiGenePublicationRequest();
     r.geneId = "PF3D7_1133400";
-    r.documentType = "upload";
+    r.documentType = SourceKind.UPLOAD;
     r.paperText = "The gene PF3D7_1133400 is discussed at length.";
     r.pdfContentSha256 = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"; // 64 hex
     return r;
@@ -43,7 +45,7 @@ public class SyncPreludeTest {
   @Test(expected = BadRequestException.class)
   public void validate_rejectsUnknownDocumentType() {
     AiGenePublicationRequest r = pubmedRequest();
-    r.documentType = "carrier-pigeon";
+    r.documentType = SourceKind.fromWire("carrier-pigeon"); // unrecognised → null
     SyncPrelude.validate(r);
   }
 
@@ -72,27 +74,27 @@ public class SyncPreludeTest {
   public void validate_normalisesUploadPubmedRef() {
     AiGenePublicationRequest r = uploadRequest();
     r.externalRef = "  PMID: 12345678 ";
-    r.externalRefKind = "pubmed";
+    r.externalRefKind = ExternalRefKind.PUBMED;
     SyncPrelude.validate(r);
     org.junit.Assert.assertEquals("12345678", r.externalRef);
-    org.junit.Assert.assertEquals("pubmed", r.externalRefKind);
+    org.junit.Assert.assertEquals(ExternalRefKind.PUBMED, r.externalRefKind);
   }
 
   @Test
   public void validate_normalisesUploadDoiRef() {
     AiGenePublicationRequest r = uploadRequest();
     r.externalRef = "https://doi.org/10.1234/abc.def";
-    r.externalRefKind = "doi";
+    r.externalRefKind = ExternalRefKind.DOI;
     SyncPrelude.validate(r);
     org.junit.Assert.assertEquals("10.1234/abc.def", r.externalRef);
-    org.junit.Assert.assertEquals("doi", r.externalRefKind);
+    org.junit.Assert.assertEquals(ExternalRefKind.DOI, r.externalRefKind);
   }
 
   @Test(expected = javax.ws.rs.BadRequestException.class)
   public void validate_rejectsMalformedExternalRef() {
     AiGenePublicationRequest r = uploadRequest();
     r.externalRef = "not-a-pmid";
-    r.externalRefKind = "pubmed";
+    r.externalRefKind = ExternalRefKind.PUBMED;
     SyncPrelude.validate(r);
   }
 
@@ -100,7 +102,7 @@ public class SyncPreludeTest {
   public void validate_clearsExternalRefOnPubmedPath() {
     AiGenePublicationRequest r = pubmedRequest();
     r.externalRef = "12345678";
-    r.externalRefKind = "pubmed";
+    r.externalRefKind = ExternalRefKind.PUBMED;
     SyncPrelude.validate(r);
     org.junit.Assert.assertNull(r.externalRef);
     org.junit.Assert.assertNull(r.externalRefKind);


### PR DESCRIPTION
Here's a tidy-up of the string variables but note that the sealed interface `switch` statements using pattern matching require Java 21 (which we have) - but is that too bleeding edge?

e.g. here
https://github.com/VEuPathDB/ApiCommonWebsite/blob/bff0aaadf827f896d5ec52ffc7a7e3ccde3618fd/Model/src/main/java/org/apidb/apicommon/model/comment/repo/InsertCommentAiRunQuery.java#L87-L95

---

## What changed

**New Model types** (`model/comment/pojo`):
- `SourceKind`, `ExternalRefKind` — enums with `@JsonValue`/lenient `@JsonCreator` (following the `ReferenceType` convention), so unknown wire values parse to `null` and validation still emits the documented 400s.
- `AiRunSource` — sealed interface + `Pubmed`/`Upload` records; the shared source union.
- `JobStatus` — **moved** here from Service, with a new `fromWireValue`.
- `AiRunSourceRows` (repo) — one `ResultSet → AiRunSource` mapper shared by both read queries.

**The four duplicated iff-sites are now single exhaustive `switch`es** on the sealed type: request validation (`SyncPrelude`), the fetch-vs-supplied-text branch (`AiGenePublicationPipeline`), write-side `sourceJson`, and read-side provenance (`GetCommentAiProvenanceQuery`, which now reuses `AiRunSource` — the old parallel `AiProvenanceView.Source` union is deleted). `CommentAiRun` holds one `AiRunSource` + a `JobStatus` terminal status instead of nine string fields.

## Verification
- Model builds; Service compiles; **all 145 tests pass** — including `AiProvenanceViewTest` (camelCase Jackson union, the highest-risk wire check), `AiGenePublicationPublishTest` (snake_case `sourceJson`), and `JobDigestTest` (digest unchanged → no cache invalidation).

## Two things to flag for your review
1. **`JobStatus` moved Service → Model** (as we discussed — the only way to type it onto `CommentAiRun` without a layering violation). Seven Service files gained an import; no logic/wire change.
2. **The DB query layer (`Insert`/`Get`) has no unit test** — those need a live DB and never had one. Compatibility is preserved *by construction*: the SQL column list and `TYPES` array are untouched; only how values are read/bound changed, and `AiRunSourceRows` mirrors the deleted inline branch exactly. Worth a manual round-trip check in a dev environment before merge if you want belt-and-suspenders.
