### PR TITLE
BED reporter and feature provider for strain genomic segments

### DIFF
--- a/Model/src/main/java/org/apidb/apicommon/model/report/bed/BedStrainSegmentReporter.java
+++ b/Model/src/main/java/org/apidb/apicommon/model/report/bed/BedStrainSegmentReporter.java
@@ -10,9 +10,13 @@ import org.json.JSONObject;
  * BED reporter for the strain genomic segment record class.
  *
  * There is only one feature provider, so unlike BedGenomicSequenceReporter there is no
- * resultType switch: the reporter's whole job is to hand BedReporter.configure the
- * provider, which validates the record class and the declared attributes at configure
- * time (so a mis-named attribute surfaces on first use rather than at compile time).
+ * resultType switch: the reporter's whole job is to hand the provider to
+ * BedReporter.configure.  The provider only DECLARES its required record class and
+ * attributes; BedReporter.configure is what validates them -- it compares
+ * getRequiredRecordClassFullName() against the answer's record class and resolves each
+ * declared attribute/table name through getFieldsByName, which throws
+ * WdkRuntimeException for a name the record class does not have.  So a mis-named attribute
+ * surfaces at configure time (first use of the reporter), not at compile time.
  */
 public class BedStrainSegmentReporter extends BedReporter {
 

--- a/Model/src/main/java/org/apidb/apicommon/model/report/bed/BedStrainSegmentReporter.java
+++ b/Model/src/main/java/org/apidb/apicommon/model/report/bed/BedStrainSegmentReporter.java
@@ -1,0 +1,24 @@
+package org.apidb.apicommon.model.report.bed;
+
+import org.apidb.apicommon.model.report.bed.feature.StrainSegmentFeatureProvider;
+import org.gusdb.wdk.model.WdkModelException;
+import org.gusdb.wdk.model.report.Reporter;
+import org.gusdb.wdk.model.report.ReporterConfigException;
+import org.json.JSONObject;
+
+/**
+ * BED reporter for the strain genomic segment record class.
+ *
+ * There is only one feature provider, so unlike BedGenomicSequenceReporter there is no
+ * resultType switch: the reporter's whole job is to hand BedReporter.configure the
+ * provider, which validates the record class and the declared attributes at configure
+ * time (so a mis-named attribute surfaces on first use rather than at compile time).
+ */
+public class BedStrainSegmentReporter extends BedReporter {
+
+  @Override
+  public Reporter configure(JSONObject config) throws ReporterConfigException, WdkModelException {
+    return configure(() -> new StrainSegmentFeatureProvider(config), getContentDisposition(config));
+  }
+
+}

--- a/Model/src/main/java/org/apidb/apicommon/model/report/bed/feature/StrainSegmentFeatureProvider.java
+++ b/Model/src/main/java/org/apidb/apicommon/model/report/bed/feature/StrainSegmentFeatureProvider.java
@@ -1,0 +1,185 @@
+package org.apidb.apicommon.model.report.bed.feature;
+
+import java.util.List;
+
+import org.apidb.apicommon.model.report.bed.util.BedLine;
+import org.apidb.apicommon.model.report.bed.util.DeflineBuilder;
+import org.apidb.apicommon.model.report.bed.util.RequestedDeflineFields;
+import org.apidb.apicommon.model.report.bed.util.StrainSegmentId;
+import org.gusdb.wdk.model.WdkModelException;
+import org.gusdb.wdk.model.WdkUserException;
+import org.gusdb.wdk.model.record.RecordInstance;
+import org.gusdb.wdk.model.record.attribute.AttributeValue;
+import org.json.JSONObject;
+
+/**
+ * Emits one BED line per strain genomic segment.
+ *
+ * The two columns have very different constraints (spec section 7):
+ *
+ * - chrom is HARD: it must equal the strain consensus FASTA key ({@code <strain>_<refSeq>},
+ *   written by dnaseq-nextflow as {@code <sample>_<chrom>}), or the FASTA index lookup
+ *   fails.  It is taken from the {@code strain_seq_id} ATTRIBUTE rather than recomputed
+ *   here, so the model stays the single source of truth for the key that was looked up.
+ * - name is FREE: under {@code deflineFormat=QUERYONLY} seqret emits {@code '>' + name}
+ *   verbatim, so it becomes the eventual FASTA defline.  It carries provenance, i.e. both
+ *   coordinate systems.  RequestedDeflineFields is populated only when the caller passes
+ *   {@code deflineType=full}, so by default the name column is the bare primary key.
+ *
+ * Reference coordinates are parsed from the primary key by {@link StrainSegmentId}, which
+ * already validates {@code refStart >= 1}, {@code refEnd >= refStart} and forward/reverse
+ * strand.  The STRAIN coordinates it knows nothing about, so they are validated here: they
+ * arrive deliberately UNCLAMPED from {@code StrainSegmentAttributes.Coords} (spec 5.3.2),
+ * so a segment lying inside a deletion reports {@code strain_end < strain_start}.  Nothing
+ * upstream rejects that, and an inverted interval reaching a FASTA lookup is a silent wrong
+ * answer, so it must fail loudly here.
+ */
+public class StrainSegmentFeatureProvider implements BedFeatureProvider {
+
+  private static final String ATTR_STRAIN_SEQ_ID = "strain_seq_id";
+  private static final String ATTR_STRAIN_START = "strain_start";
+  private static final String ATTR_STRAIN_END = "strain_end";
+  private static final String ATTR_ORGANISM = "organism";
+
+  private final RequestedDeflineFields _requestedDeflineFields;
+
+  public StrainSegmentFeatureProvider(JSONObject config) {
+    _requestedDeflineFields = new RequestedDeflineFields(config);
+  }
+
+  @Override
+  public String getRequiredRecordClassFullName() {
+    return "StrainSegmentRecordClasses.StrainSegmentRecordClass";
+  }
+
+  @Override
+  public String[] getRequiredAttributeNames() {
+    // strain and the reference range come from the primary key, so they need no attribute
+    return new String[] {
+        ATTR_STRAIN_SEQ_ID,
+        ATTR_STRAIN_START,
+        ATTR_STRAIN_END,
+        ATTR_ORGANISM
+    };
+  }
+
+  @Override
+  public String[] getRequiredTableNames() {
+    return new String[0];
+  }
+
+  @Override
+  public List<List<String>> getRecordAsBedFields(RecordInstance record) throws WdkModelException {
+    String featureId = getSourceId(record);
+
+    StrainSegmentId id;
+    try {
+      id = StrainSegmentId.parse(featureId);
+    }
+    catch (IllegalArgumentException e) {
+      throw new WdkModelException(e.getMessage(), e);
+    }
+
+    // chrom must be the FASTA key; take it from the attribute rather than recomputing it,
+    // so the model stays the single source of truth for what was looked up.
+    String strainSeqId = requiredStringAttribute(record, ATTR_STRAIN_SEQ_ID, featureId);
+    int strainStart = requiredIntegerAttribute(record, ATTR_STRAIN_START, featureId);
+    int strainEnd = requiredIntegerAttribute(record, ATTR_STRAIN_END, featureId);
+
+    validateStrainInterval(featureId, strainSeqId, strainStart, strainEnd);
+
+    DeflineBuilder defline = new DeflineBuilder(featureId);
+
+    if (_requestedDeflineFields.contains("organism")) {
+      defline.appendRecordAttribute(record, ATTR_ORGANISM);
+    }
+    if (_requestedDeflineFields.contains("strain")) {
+      defline.appendValue(id.getStrain());
+    }
+    if (_requestedDeflineFields.contains("description")) {
+      defline.appendValue("segment of strain genomic sequence");
+    }
+    if (_requestedDeflineFields.contains("reference_position")) {
+      defline.appendPosition(id.getRefSeq(), id.getRefStart(), id.getRefEnd(), id.getStrand());
+    }
+    if (_requestedDeflineFields.contains("position")) {
+      defline.appendPosition(strainSeqId, strainStart, strainEnd, id.getStrand());
+    }
+    if (_requestedDeflineFields.contains("segment_length")) {
+      defline.appendSegmentLength(strainStart, strainEnd);
+    }
+
+    // bed6 converts start to 0-based itself, so pass 1-based coordinates
+    return List.of(BedLine.bed6(strainSeqId, strainStart, strainEnd, defline, id.getStrand()));
+  }
+
+  /**
+   * Rejects a strain interval that cannot be a BED feature.  Extracted as a static method
+   * with no WDK plumbing so it is directly unit testable (constructing a RecordInstance
+   * requires a loaded model); see StrainSegmentFeatureProviderTest.
+   *
+   * Two failure modes, both silent if not caught here:
+   * - start below 1 would reach BedLine.locationToZeroBased and emit chromStart = -1;
+   * - end below start is the inverted interval of spec 5.3.2 - the segment lies inside a
+   *   deletion, so the reference bases do not exist in this strain and the range maps to
+   *   nothing.  Left unclamped by the attribute query precisely so this check can see it.
+   */
+  static void validateStrainInterval(String featureId, String strainSeqId, int strainStart,
+      int strainEnd) throws WdkModelException {
+    if (strainStart < 1) {
+      throw new WdkModelException(String.format(
+          "Strain segment '%s' maps to strain coordinates %d-%d on '%s': strain_start %d is" +
+          " less than the minimum of 1, which would emit a negative BED chromStart.",
+          featureId, strainStart, strainEnd, strainSeqId, strainStart));
+    }
+    if (strainEnd < strainStart) {
+      throw new WdkModelException(String.format(
+          "Strain segment '%s' maps to the inverted strain interval %d-%d on '%s':" +
+          " strain_end %d is less than strain_start %d, which means the requested reference" +
+          " range lies inside a deletion in this strain and has no sequence.  Refusing to" +
+          " emit a malformed BED feature.",
+          featureId, strainStart, strainEnd, strainSeqId, strainEnd, strainStart));
+    }
+  }
+
+  /**
+   * Reads a required attribute as a non-empty string.  AttributeValue.toString() renders a
+   * NULL column value as the empty string, so "absent" and "empty" are indistinguishable
+   * downstream; both are a defect here, and both name the primary key and the attribute.
+   */
+  private static String requiredStringAttribute(RecordInstance record, String key, String featureId)
+      throws WdkModelException {
+    AttributeValue value;
+    try {
+      value = record.getAttributeValue(key);
+    }
+    catch (WdkUserException e) {
+      throw new WdkModelException(String.format(
+          "Strain segment '%s': could not read required attribute '%s'", featureId, key), e);
+    }
+    String stringValue = value == null ? null : value.toString();
+    if (stringValue == null || stringValue.trim().isEmpty()) {
+      throw new WdkModelException(String.format(
+          "Strain segment '%s' has no value for required attribute '%s'", featureId, key));
+    }
+    return stringValue.trim();
+  }
+
+  /**
+   * Reads a required attribute as an int.  Deliberately NOT
+   * {@code integerValueWithZeroForEmpty}: that maps a missing value to 0, which would then
+   * be reported as an out-of-range coordinate rather than as the missing attribute it is.
+   */
+  private static int requiredIntegerAttribute(RecordInstance record, String key, String featureId)
+      throws WdkModelException {
+    String stringValue = requiredStringAttribute(record, key, featureId);
+    try {
+      return Integer.parseInt(stringValue);
+    }
+    catch (NumberFormatException e) {
+      throw new WdkModelException(String.format(
+          "Strain segment '%s' has non-numeric or out-of-range value '%s' for required" +
+          " integer attribute '%s'", featureId, stringValue, key), e);
+    }
+  }
+}

--- a/Model/src/main/java/org/apidb/apicommon/model/report/bed/feature/StrainSegmentFeatureProvider.java
+++ b/Model/src/main/java/org/apidb/apicommon/model/report/bed/feature/StrainSegmentFeatureProvider.java
@@ -20,11 +20,20 @@ import org.json.JSONObject;
  * - chrom is HARD: it must equal the strain consensus FASTA key ({@code <strain>_<refSeq>},
  *   written by dnaseq-nextflow as {@code <sample>_<chrom>}), or the FASTA index lookup
  *   fails.  It is taken from the {@code strain_seq_id} ATTRIBUTE rather than recomputed
- *   here, so the model stays the single source of truth for the key that was looked up.
+ *   here, so the model stays the single source of truth for the key that was looked up --
+ *   but it is then cross-checked against {@link StrainSegmentId#getStrainSeqId()}, see
+ *   {@link #validateStrainSeqIdMatchesId}.
  * - name is FREE: under {@code deflineFormat=QUERYONLY} seqret emits {@code '>' + name}
  *   verbatim, so it becomes the eventual FASTA defline.  It carries provenance, i.e. both
  *   coordinate systems.  RequestedDeflineFields is populated only when the caller passes
  *   {@code deflineType=full}, so by default the name column is the bare primary key.
+ *
+ * The accepted {@code deflineFields} vocabulary (there is no record page, so nothing else
+ * enumerates it) is exactly: {@code organism}, {@code strain}, {@code description},
+ * {@code reference_position}, {@code position}, {@code segment_length}.  {@code strain} and
+ * {@code reference_position} have no precedent in the other providers; they exist because a
+ * strain segment has two coordinate systems and the defline must record both.  Unrecognised
+ * names are silently ignored by {@link RequestedDeflineFields}.
  *
  * Reference coordinates are parsed from the primary key by {@link StrainSegmentId}, which
  * already validates {@code refStart >= 1}, {@code refEnd >= refStart} and forward/reverse
@@ -86,12 +95,17 @@ public class StrainSegmentFeatureProvider implements BedFeatureProvider {
     int strainStart = requiredIntegerAttribute(record, ATTR_STRAIN_START, featureId);
     int strainEnd = requiredIntegerAttribute(record, ATTR_STRAIN_END, featureId);
 
+    // LOAD-BEARING ORDER: both validations must run BEFORE the DeflineBuilder and
+    // BedLine.bed6 calls below.  Neither of those inspects its arguments, so moving a check
+    // after them -- or swapping the strainStart/strainEnd arguments -- emits a malformed
+    // feature with no error anywhere and nothing here would fail.
+    validateStrainSeqIdMatchesId(featureId, id, strainSeqId);
     validateStrainInterval(featureId, strainSeqId, strainStart, strainEnd);
 
     DeflineBuilder defline = new DeflineBuilder(featureId);
 
     if (_requestedDeflineFields.contains("organism")) {
-      defline.appendRecordAttribute(record, ATTR_ORGANISM);
+      defline.appendValue(requiredStringAttribute(record, ATTR_ORGANISM, featureId));
     }
     if (_requestedDeflineFields.contains("strain")) {
       defline.appendValue(id.getStrain());
@@ -111,6 +125,33 @@ public class StrainSegmentFeatureProvider implements BedFeatureProvider {
 
     // bed6 converts start to 0-based itself, so pass 1-based coordinates
     return List.of(BedLine.bed6(strainSeqId, strainStart, strainEnd, defline, id.getStrand()));
+  }
+
+  /**
+   * Cross-checks the chrom column against the primary key it must agree with.
+   *
+   * {@code chrom} is read from the {@code strain_seq_id} attribute (the model stays the
+   * source of truth), while {@link StrainSegmentId#getStrainSeqId()} computes the identical
+   * key from the primary key, and the SQL builds it the same way
+   * ({@code ids.strain || '_' || ids.ref_seq}).  Today they cannot disagree.  This exists
+   * for the day someone rewrites that column -- sourcing strain from
+   * {@code study.protocolappnode.name} instead of {@code split_part}, say -- because a
+   * mismatch there is a BED line pointing at the WRONG CONTIG with no error at all, which is
+   * precisely the failure this record class exists to prevent.  It is also the only
+   * production consumer of {@code getStrainSeqId()}, whose javadoc already promises it is the
+   * chrom column; without this the promise is tested but never exercised.
+   */
+  static void validateStrainSeqIdMatchesId(String featureId, StrainSegmentId id,
+      String strainSeqId) throws WdkModelException {
+    String expected = id.getStrainSeqId();
+    if (!expected.equals(strainSeqId)) {
+      throw new WdkModelException(String.format(
+          "Strain segment '%s' has strain_seq_id attribute '%s', which does not equal '%s'," +
+          " the key computed from its primary key.  These must be identical: strain_seq_id" +
+          " is the BED chrom column and therefore the key into the strain consensus FASTA," +
+          " so a mismatch would emit a feature on the wrong contig without any error.",
+          featureId, strainSeqId, expected));
+    }
   }
 
   /**

--- a/Model/src/main/java/org/apidb/apicommon/model/report/bed/util/StrainSegmentId.java
+++ b/Model/src/main/java/org/apidb/apicommon/model/report/bed/util/StrainSegmentId.java
@@ -1,0 +1,77 @@
+package org.apidb.apicommon.model.report.bed.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * The single parse/format authority for the strain genomic segment primary key.
+ *
+ * Grammar: {@code <strain>:<refSeq>:<refStart>-<refEnd>:<f|r>}
+ * Example: {@code A0003:AACB03000001:100-200:f}
+ *
+ * Coordinates are 1-based, inclusive, and expressed in REFERENCE coordinates.
+ * Strain coordinates are derived by the attribute query, not stored here.
+ *
+ * Note the field patterns are {@code [^:]+} rather than DynSpan's greedy {@code (.*)}.
+ * DynSpan's SQL and Java parsers disagree on IDs containing extra colons; this one
+ * rejects them instead of guessing.
+ */
+public class StrainSegmentId {
+
+  private static final Pattern PATTERN =
+      Pattern.compile("^([^:]+):([^:]+):(\\d+)-(\\d+):(f|r)$");
+
+  private final String _strain;
+  private final String _refSeq;
+  private final int _refStart;
+  private final int _refEnd;
+  private final StrandDirection _strand;
+
+  private StrainSegmentId(String strain, String refSeq, int refStart, int refEnd,
+      StrandDirection strand) {
+    _strain = strain;
+    _refSeq = refSeq;
+    _refStart = refStart;
+    _refEnd = refEnd;
+    _strand = strand;
+  }
+
+  public static StrainSegmentId parse(String sourceId) {
+    if (sourceId == null) {
+      throw new IllegalArgumentException("Strain segment ID may not be null");
+    }
+    Matcher m = PATTERN.matcher(sourceId);
+    if (!m.matches()) {
+      throw new IllegalArgumentException(String.format(
+          "Strain segment ID '%s' does not match required pattern %s",
+          sourceId, PATTERN.pattern()));
+    }
+    int start = Integer.parseInt(m.group(3));
+    int end = Integer.parseInt(m.group(4));
+    if (start > end) {
+      throw new IllegalArgumentException(String.format(
+          "Strain segment ID '%s' has start %d greater than end %d", sourceId, start, end));
+    }
+    return new StrainSegmentId(m.group(1), m.group(2), start, end,
+        StrandDirection.fromEfOrEr(m.group(5)));
+  }
+
+  public String format() {
+    return String.format("%s:%s:%d-%d:%s", _strain, _refSeq, _refStart, _refEnd,
+        StrandDirection.reverse.equals(_strand) ? "r" : "f");
+  }
+
+  /**
+   * The key into the strain consensus FASTA, and therefore the BED chrom column.
+   * Written by dnaseq-nextflow as {@code <sample>_<chrom>}.
+   */
+  public String getStrainSeqId() {
+    return _strain + "_" + _refSeq;
+  }
+
+  public String getStrain() { return _strain; }
+  public String getRefSeq() { return _refSeq; }
+  public int getRefStart() { return _refStart; }
+  public int getRefEnd() { return _refEnd; }
+  public StrandDirection getStrand() { return _strand; }
+}

--- a/Model/src/main/java/org/apidb/apicommon/model/report/bed/util/StrainSegmentId.java
+++ b/Model/src/main/java/org/apidb/apicommon/model/report/bed/util/StrainSegmentId.java
@@ -15,11 +15,16 @@ import java.util.regex.Pattern;
  * Note the field patterns are {@code [^:]+} rather than DynSpan's greedy {@code (.*)}.
  * DynSpan's SQL and Java parsers disagree on IDs containing extra colons; this one
  * rejects them instead of guessing.
+ *
+ * ':' is the only delimiter, and the only character excluded from the strain and
+ * refSeq fields. In particular both may contain underscores: of 6,119 strain names
+ * carrying indel data, 1,494 (24%) contain an underscore and 0 contain a colon.
+ * This matches the SQL side, which also splits on ':' alone.
  */
 public class StrainSegmentId {
 
   private static final Pattern PATTERN =
-      Pattern.compile("^([^:_]+):([^:]+):(\\d+)-(\\d+):(f|r)$");
+      Pattern.compile("^([^:]+):([^:]+):(\\d+)-(\\d+):(f|r)$");
 
   private final String _strain;
   private final String _refSeq;
@@ -90,10 +95,16 @@ public class StrainSegmentId {
    * The key into the strain consensus FASTA, and therefore the BED chrom column.
    * Written by dnaseq-nextflow as {@code <sample>_<chrom>}.
    *
-   * The strain field is constrained to contain no underscore (see PATTERN) because
-   * reference sequence IDs legitimately do (e.g. {@code Pf3D7_01_v3}); without that
-   * constraint, two different (strain, refSeq) pairs could concatenate to the same
-   * ambiguous key.
+   * OPAQUE AND ONE-WAY: this is a lookup key only. It must never be split back into
+   * strain and refSeq. Both fields legitimately contain underscores -- 24% of strain
+   * names carrying indel data do (e.g. {@code Af293_resequence2}, {@code USGS_28834_1_NV}),
+   * as do reference sequence IDs (e.g. {@code Chr1_A_fumigatus_Af293}) -- so
+   * {@code A_B} + {@code C} is indistinguishable from {@code A} + {@code B_C}. No
+   * narrowing of the grammar can make it reversible, and narrowing it enough to try
+   * would reject a quarter of all real primary keys.
+   *
+   * A consumer that needs the strain or the reference sequence parses the primary key
+   * instead, where ':' delimits unambiguously (no strain name contains a colon).
    */
   public String getStrainSeqId() {
     return _strain + "_" + _refSeq;

--- a/Model/src/main/java/org/apidb/apicommon/model/report/bed/util/StrainSegmentId.java
+++ b/Model/src/main/java/org/apidb/apicommon/model/report/bed/util/StrainSegmentId.java
@@ -19,7 +19,7 @@ import java.util.regex.Pattern;
 public class StrainSegmentId {
 
   private static final Pattern PATTERN =
-      Pattern.compile("^([^:]+):([^:]+):(\\d+)-(\\d+):(f|r)$");
+      Pattern.compile("^([^:_]+):([^:]+):(\\d+)-(\\d+):(f|r)$");
 
   private final String _strain;
   private final String _refSeq;
@@ -27,8 +27,22 @@ public class StrainSegmentId {
   private final int _refEnd;
   private final StrandDirection _strand;
 
-  private StrainSegmentId(String strain, String refSeq, int refStart, int refEnd,
+  private StrainSegmentId(String sourceId, String strain, String refSeq, int refStart, int refEnd,
       StrandDirection strand) {
+    if (refStart < 1) {
+      throw new IllegalArgumentException(String.format(
+          "Strain segment ID '%s' has refStart %d, which is less than the minimum of 1",
+          sourceId, refStart));
+    }
+    if (refEnd < refStart) {
+      throw new IllegalArgumentException(String.format(
+          "Strain segment ID '%s' has end %d less than start %d", sourceId, refEnd, refStart));
+    }
+    if (!StrandDirection.forward.equals(strand) && !StrandDirection.reverse.equals(strand)) {
+      throw new IllegalArgumentException(String.format(
+          "Strain segment ID '%s' has strand %s, which must be forward or reverse",
+          sourceId, strand));
+    }
     _strain = strain;
     _refSeq = refSeq;
     _refStart = refStart;
@@ -46,16 +60,27 @@ public class StrainSegmentId {
           "Strain segment ID '%s' does not match required pattern %s",
           sourceId, PATTERN.pattern()));
     }
-    int start = Integer.parseInt(m.group(3));
-    int end = Integer.parseInt(m.group(4));
-    if (start > end) {
-      throw new IllegalArgumentException(String.format(
-          "Strain segment ID '%s' has start %d greater than end %d", sourceId, start, end));
-    }
-    return new StrainSegmentId(m.group(1), m.group(2), start, end,
+    int start = parseCoordinate(sourceId, m.group(3));
+    int end = parseCoordinate(sourceId, m.group(4));
+    return new StrainSegmentId(sourceId, m.group(1), m.group(2), start, end,
         StrandDirection.fromEfOrEr(m.group(5)));
   }
 
+  private static int parseCoordinate(String sourceId, String coordinate) {
+    try {
+      return Integer.parseInt(coordinate);
+    }
+    catch (NumberFormatException e) {
+      throw new IllegalArgumentException(String.format(
+          "Strain segment ID '%s' has non-numeric or out-of-range coordinate '%s'",
+          sourceId, coordinate), e);
+    }
+  }
+
+  /**
+   * Returns the canonical form of this ID, equal to the input for canonical input
+   * (e.g. an input with leading zeros in its coordinates re-formats without them).
+   */
   public String format() {
     return String.format("%s:%s:%d-%d:%s", _strain, _refSeq, _refStart, _refEnd,
         StrandDirection.reverse.equals(_strand) ? "r" : "f");
@@ -64,6 +89,11 @@ public class StrainSegmentId {
   /**
    * The key into the strain consensus FASTA, and therefore the BED chrom column.
    * Written by dnaseq-nextflow as {@code <sample>_<chrom>}.
+   *
+   * The strain field is constrained to contain no underscore (see PATTERN) because
+   * reference sequence IDs legitimately do (e.g. {@code Pf3D7_01_v3}); without that
+   * constraint, two different (strain, refSeq) pairs could concatenate to the same
+   * ambiguous key.
    */
   public String getStrainSeqId() {
     return _strain + "_" + _refSeq;

--- a/Model/src/test/java/org/apidb/apicommon/model/report/bed/feature/StrainSegmentFeatureProviderTest.java
+++ b/Model/src/test/java/org/apidb/apicommon/model/report/bed/feature/StrainSegmentFeatureProviderTest.java
@@ -1,0 +1,89 @@
+package org.apidb.apicommon.model.report.bed.feature;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.gusdb.wdk.model.WdkModelException;
+import org.junit.Test;
+
+/**
+ * Covers the strain-coordinate validation the provider adds on top of
+ * {@link org.apidb.apicommon.model.report.bed.util.StrainSegmentId}, which validates only
+ * the REFERENCE coordinates in the primary key and knows nothing about strain coordinates.
+ *
+ * Only the static seam is exercised: getRecordAsBedFields needs a RecordInstance, which
+ * needs a loaded WDK model, so the record-reading path is covered end to end instead
+ * (spec section 9 / plan Task 7).
+ */
+public class StrainSegmentFeatureProviderTest {
+
+  @Test
+  public void acceptsForwardInterval() throws Exception {
+    StrainSegmentFeatureProvider.validateStrainInterval(
+        "A0003:AACB03000001:100-200:f", "A0003_AACB03000001", 143, 241);
+  }
+
+  @Test
+  public void acceptsSingleBaseInterval() throws Exception {
+    StrainSegmentFeatureProvider.validateStrainInterval(
+        "A0003:AACB03000001:100-100:f", "A0003_AACB03000001", 143, 143);
+  }
+
+  /**
+   * The live case from spec 5.3.2: a 1-bp segment on a shift = -54 deletion event.  The
+   * attribute query deliberately leaves these unclamped, so this is the only thing standing
+   * between an inverted interval and a FASTA lookup that would return wrong sequence.
+   */
+  @Test
+  public void rejectsInvertedIntervalInsideADeletion() {
+    try {
+      StrainSegmentFeatureProvider.validateStrainInterval(
+          "366.1:Pf3D7_10_v3:331757-331757:f", "366.1_Pf3D7_10_v3", 331658, 331604);
+      fail("expected an inverted strain interval to be rejected");
+    }
+    catch (WdkModelException e) {
+      // the message must name the primary key and BOTH coordinates
+      assertTrue(e.getMessage(), e.getMessage().contains("366.1:Pf3D7_10_v3:331757-331757:f"));
+      assertTrue(e.getMessage(), e.getMessage().contains("331658"));
+      assertTrue(e.getMessage(), e.getMessage().contains("331604"));
+    }
+  }
+
+  @Test
+  public void rejectsOffByOneInversion() {
+    try {
+      StrainSegmentFeatureProvider.validateStrainInterval(
+          "A0003:AACB03000001:100-200:f", "A0003_AACB03000001", 143, 142);
+      fail("expected an inverted strain interval to be rejected");
+    }
+    catch (WdkModelException e) {
+      assertTrue(e.getMessage(), e.getMessage().contains("inverted"));
+    }
+  }
+
+  /** A start below 1 would reach BedLine.locationToZeroBased and emit chromStart = -1. */
+  @Test
+  public void rejectsStartBelowOne() {
+    try {
+      StrainSegmentFeatureProvider.validateStrainInterval(
+          "A0003:AACB03000001:100-200:f", "A0003_AACB03000001", 0, 241);
+      fail("expected a strain_start below 1 to be rejected");
+    }
+    catch (WdkModelException e) {
+      assertTrue(e.getMessage(), e.getMessage().contains("A0003:AACB03000001:100-200:f"));
+      assertTrue(e.getMessage(), e.getMessage().contains("minimum of 1"));
+    }
+  }
+
+  @Test
+  public void rejectsNegativeStart() {
+    try {
+      StrainSegmentFeatureProvider.validateStrainInterval(
+          "A0003:AACB03000001:100-200:f", "A0003_AACB03000001", -5, 241);
+      fail("expected a negative strain_start to be rejected");
+    }
+    catch (WdkModelException e) {
+      assertTrue(e.getMessage(), e.getMessage().contains("-5"));
+    }
+  }
+}

--- a/Model/src/test/java/org/apidb/apicommon/model/report/bed/feature/StrainSegmentFeatureProviderTest.java
+++ b/Model/src/test/java/org/apidb/apicommon/model/report/bed/feature/StrainSegmentFeatureProviderTest.java
@@ -3,17 +3,19 @@ package org.apidb.apicommon.model.report.bed.feature;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.apidb.apicommon.model.report.bed.util.StrainSegmentId;
 import org.gusdb.wdk.model.WdkModelException;
 import org.junit.Test;
 
 /**
- * Covers the strain-coordinate validation the provider adds on top of
+ * Covers the validation the provider adds on top of
  * {@link org.apidb.apicommon.model.report.bed.util.StrainSegmentId}, which validates only
- * the REFERENCE coordinates in the primary key and knows nothing about strain coordinates.
+ * the REFERENCE coordinates in the primary key and knows nothing about strain coordinates
+ * or about the strain_seq_id attribute.
  *
- * Only the static seam is exercised: getRecordAsBedFields needs a RecordInstance, which
- * needs a loaded WDK model, so the record-reading path is covered end to end instead
- * (spec section 9 / plan Task 7).
+ * Only the static seams are exercised: getRecordAsBedFields needs a RecordInstance, which
+ * needs a loaded WDK model, so the record-reading path is to be covered end to end by
+ * plan Task 7 (spec section 9), which has not run yet.
  */
 public class StrainSegmentFeatureProviderTest {
 
@@ -30,60 +32,114 @@ public class StrainSegmentFeatureProviderTest {
   }
 
   /**
+   * The accept side of the strainStart boundary.  Without this, '<' silently becoming '<='
+   * still passes every reject test while breaking every segment that starts at position 1
+   * of a contig - which is a real case, not a corner one.
+   */
+  @Test
+  public void acceptsStartAtExactlyOne() throws Exception {
+    StrainSegmentFeatureProvider.validateStrainInterval(
+        "A0003:AACB03000001:1-1:f", "A0003_AACB03000001", 1, 1);
+  }
+
+  /**
    * The live case from spec 5.3.2: a 1-bp segment on a shift = -54 deletion event.  The
    * attribute query deliberately leaves these unclamped, so this is the only thing standing
    * between an inverted interval and a FASTA lookup that would return wrong sequence.
+   *
+   * The message must name the primary key and BOTH coordinates.
    */
   @Test
   public void rejectsInvertedIntervalInsideADeletion() {
-    try {
-      StrainSegmentFeatureProvider.validateStrainInterval(
-          "366.1:Pf3D7_10_v3:331757-331757:f", "366.1_Pf3D7_10_v3", 331658, 331604);
-      fail("expected an inverted strain interval to be rejected");
-    }
-    catch (WdkModelException e) {
-      // the message must name the primary key and BOTH coordinates
-      assertTrue(e.getMessage(), e.getMessage().contains("366.1:Pf3D7_10_v3:331757-331757:f"));
-      assertTrue(e.getMessage(), e.getMessage().contains("331658"));
-      assertTrue(e.getMessage(), e.getMessage().contains("331604"));
-    }
+    assertIntervalRejected("366.1:Pf3D7_10_v3:331757-331757:f", "366.1_Pf3D7_10_v3",
+        331658, 331604, "366.1:Pf3D7_10_v3:331757-331757:f", "331658", "331604");
   }
 
   @Test
   public void rejectsOffByOneInversion() {
-    try {
-      StrainSegmentFeatureProvider.validateStrainInterval(
-          "A0003:AACB03000001:100-200:f", "A0003_AACB03000001", 143, 142);
-      fail("expected an inverted strain interval to be rejected");
-    }
-    catch (WdkModelException e) {
-      assertTrue(e.getMessage(), e.getMessage().contains("inverted"));
-    }
+    assertIntervalRejected("A0003:AACB03000001:100-200:f", "A0003_AACB03000001",
+        143, 142, "inverted");
   }
 
   /** A start below 1 would reach BedLine.locationToZeroBased and emit chromStart = -1. */
   @Test
   public void rejectsStartBelowOne() {
-    try {
-      StrainSegmentFeatureProvider.validateStrainInterval(
-          "A0003:AACB03000001:100-200:f", "A0003_AACB03000001", 0, 241);
-      fail("expected a strain_start below 1 to be rejected");
-    }
-    catch (WdkModelException e) {
-      assertTrue(e.getMessage(), e.getMessage().contains("A0003:AACB03000001:100-200:f"));
-      assertTrue(e.getMessage(), e.getMessage().contains("minimum of 1"));
-    }
+    assertIntervalRejected("A0003:AACB03000001:100-200:f", "A0003_AACB03000001",
+        0, 241, "A0003:AACB03000001:100-200:f", "minimum of 1");
   }
 
   @Test
   public void rejectsNegativeStart() {
+    assertIntervalRejected("A0003:AACB03000001:100-200:f", "A0003_AACB03000001",
+        -5, 241, "-5");
+  }
+
+  // ---- the chrom / primary key cross-check -------------------------------------------
+
+  @Test
+  public void acceptsStrainSeqIdMatchingThePrimaryKey() throws Exception {
+    String featureId = "Af293_resequence2:Chr1_A_fumigatus_Af293:100-200:f";
+    StrainSegmentFeatureProvider.validateStrainSeqIdMatchesId(
+        featureId, StrainSegmentId.parse(featureId),
+        "Af293_resequence2_Chr1_A_fumigatus_Af293");
+  }
+
+  /**
+   * The failure this guards: the attribute query sourcing the strain from somewhere other
+   * than the primary key, so chrom names a contig that is not the one the ID describes.
+   */
+  @Test
+  public void rejectsStrainSeqIdThatDisagreesWithThePrimaryKey() {
+    String featureId = "A0003:AACB03000001:100-200:f";
     try {
-      StrainSegmentFeatureProvider.validateStrainInterval(
-          "A0003:AACB03000001:100-200:f", "A0003_AACB03000001", -5, 241);
-      fail("expected a negative strain_start to be rejected");
+      StrainSegmentFeatureProvider.validateStrainSeqIdMatchesId(
+          featureId, StrainSegmentId.parse(featureId), "A0004_AACB03000001");
+      fail("expected a strain_seq_id disagreeing with the primary key to be rejected");
     }
     catch (WdkModelException e) {
-      assertTrue(e.getMessage(), e.getMessage().contains("-5"));
+      // the message must name the primary key and BOTH keys
+      assertContains(e, featureId);
+      assertContains(e, "A0004_AACB03000001");
+      assertContains(e, "A0003_AACB03000001");
     }
+  }
+
+  /** An empty attribute value must not pass as "close enough" to the computed key. */
+  @Test
+  public void rejectsEmptyStrainSeqId() {
+    String featureId = "A0003:AACB03000001:100-200:f";
+    try {
+      StrainSegmentFeatureProvider.validateStrainSeqIdMatchesId(
+          featureId, StrainSegmentId.parse(featureId), "");
+      fail("expected an empty strain_seq_id to be rejected");
+    }
+    catch (WdkModelException e) {
+      assertContains(e, "A0003_AACB03000001");
+    }
+  }
+
+  /**
+   * Asserts validateStrainInterval rejects these coordinates, and that the exception message
+   * contains every expected fragment - a message that dropped the primary key or a
+   * coordinate must still fail the test, not just the absence of an exception.
+   */
+  private static void assertIntervalRejected(String featureId, String strainSeqId,
+      int strainStart, int strainEnd, String... expectedInMessage) {
+    try {
+      StrainSegmentFeatureProvider.validateStrainInterval(
+          featureId, strainSeqId, strainStart, strainEnd);
+      fail(String.format("expected strain interval %d-%d on '%s' to be rejected for '%s'",
+          strainStart, strainEnd, strainSeqId, featureId));
+    }
+    catch (WdkModelException e) {
+      for (String expected : expectedInMessage) {
+        assertContains(e, expected);
+      }
+    }
+  }
+
+  private static void assertContains(WdkModelException e, String expected) {
+    assertTrue("expected message to contain '" + expected + "', was: " + e.getMessage(),
+        e.getMessage().contains(expected));
   }
 }

--- a/Model/src/test/java/org/apidb/apicommon/model/report/bed/util/StrainSegmentIdTest.java
+++ b/Model/src/test/java/org/apidb/apicommon/model/report/bed/util/StrainSegmentIdTest.java
@@ -41,6 +41,65 @@ public class StrainSegmentIdTest {
     assertEquals(50, id.getRefEnd());
   }
 
+  // 1,494 of 6,119 strain names carrying indel data (24%) contain an underscore.
+  // An earlier strain group of [^:_]+ rejected every one of them.
+  @Test
+  public void strainNameWithUnderscoreSurvives() {
+    String sourceId = "Af293_resequence2:Chr1_A_fumigatus_Af293:1-100000:f";
+    StrainSegmentId id = StrainSegmentId.parse(sourceId);
+    assertEquals("Af293_resequence2", id.getStrain());
+    assertEquals("Chr1_A_fumigatus_Af293", id.getRefSeq());
+    assertEquals(1, id.getRefStart());
+    assertEquals(100000, id.getRefEnd());
+    assertEquals(StrandDirection.forward, id.getStrand());
+    assertEquals(sourceId, id.format());
+  }
+
+  @Test
+  public void strainNameWithMultipleUnderscoresSurvives() {
+    String sourceId = "USGS_28834_1_NV:bcin_chr_1:5-50:r";
+    StrainSegmentId id = StrainSegmentId.parse(sourceId);
+    assertEquals("USGS_28834_1_NV", id.getStrain());
+    assertEquals("bcin_chr_1", id.getRefSeq());
+    assertEquals(5, id.getRefStart());
+    assertEquals(50, id.getRefEnd());
+    assertEquals(StrandDirection.reverse, id.getStrand());
+    assertEquals(sourceId, id.format());
+  }
+
+  @Test
+  public void strainNameWithUnderscoreAndHyphenSurvives() {
+    String sourceId = "AFIS_13708_CDC-14:Chr1_A_fumigatus_Af293:100-200:f";
+    StrainSegmentId id = StrainSegmentId.parse(sourceId);
+    assertEquals("AFIS_13708_CDC-14", id.getStrain());
+    assertEquals("Chr1_A_fumigatus_Af293", id.getRefSeq());
+    assertEquals(sourceId, id.format());
+  }
+
+  @Test
+  public void strainNameOfOnlyDigitsAndUnderscoresSurvives() {
+    StrainSegmentId id = StrainSegmentId.parse("1_01_01:bcin_chr_1:1-100000:f");
+    assertEquals("1_01_01", id.getStrain());
+    assertEquals("bcin_chr_1", id.getRefSeq());
+  }
+
+  // getStrainSeqId is an opaque, one-way lookup key: a plain concatenation, even when
+  // both sides contain underscores. It is never split back apart.
+  @Test
+  public void strainSeqIdConcatenatesUnderscoreContainingStrain() {
+    assertEquals("Af293_resequence2_Chr1_A_fumigatus_Af293",
+        StrainSegmentId.parse("Af293_resequence2:Chr1_A_fumigatus_Af293:1-100000:f")
+            .getStrainSeqId());
+    assertEquals("USGS_28834_1_NV_bcin_chr_1",
+        StrainSegmentId.parse("USGS_28834_1_NV:bcin_chr_1:5-50:r").getStrainSeqId());
+  }
+
+  // ':' is the one true delimiter, so an extra one is still ambiguous and still rejected.
+  @Test
+  public void rejectsColonInStrainName() {
+    assertRejected("Af293:resequence2:Chr1_A_fumigatus_Af293:1-100000:f");
+  }
+
   @Test
   public void formatRoundTripsBothStrands() {
     String forward = "A17-48H-7:AACB03000001:5-9:f";

--- a/Model/src/test/java/org/apidb/apicommon/model/report/bed/util/StrainSegmentIdTest.java
+++ b/Model/src/test/java/org/apidb/apicommon/model/report/bed/util/StrainSegmentIdTest.java
@@ -85,6 +85,18 @@ public class StrainSegmentIdTest {
     assertRejected(null);
   }
 
+  @Test
+  public void acceptsSingleBaseSegment() {
+    StrainSegmentId id = StrainSegmentId.parse("A0003:AACB03000001:100-100:f");
+    assertEquals(100, id.getRefStart());
+    assertEquals(100, id.getRefEnd());
+  }
+
+  @Test
+  public void rejectsCoordinateBelowOne() {
+    assertRejected("A0003:AACB03000001:0-200:f");
+  }
+
   private static void assertRejected(String sourceId) {
     try {
       StrainSegmentId.parse(sourceId);

--- a/Model/src/test/java/org/apidb/apicommon/model/report/bed/util/StrainSegmentIdTest.java
+++ b/Model/src/test/java/org/apidb/apicommon/model/report/bed/util/StrainSegmentIdTest.java
@@ -1,0 +1,97 @@
+package org.apidb.apicommon.model.report.bed.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+public class StrainSegmentIdTest {
+
+  @Test
+  public void parsesForwardStrandId() {
+    StrainSegmentId id = StrainSegmentId.parse("A0003:AACB03000001:100-200:f");
+    assertEquals("A0003", id.getStrain());
+    assertEquals("AACB03000001", id.getRefSeq());
+    assertEquals(100, id.getRefStart());
+    assertEquals(200, id.getRefEnd());
+    assertEquals(StrandDirection.forward, id.getStrand());
+  }
+
+  @Test
+  public void parsesReverseStrandId() {
+    StrainSegmentId id = StrainSegmentId.parse("S7:AACB03000001:1-50:r");
+    assertEquals("S7", id.getStrain());
+    assertEquals(StrandDirection.reverse, id.getStrand());
+  }
+
+  // The BED chrom column must equal the dnaseq consensus FASTA defline,
+  // which makeConsensusFastaFromVcfAndBed.py writes as <sample>_<chrom>.
+  @Test
+  public void strainSeqIdMatchesFastaKey() {
+    assertEquals("A0003_AACB03000001",
+        StrainSegmentId.parse("A0003:AACB03000001:100-200:f").getStrainSeqId());
+  }
+
+  // Real strain names contain hyphens; the range is a separate colon field so this is safe.
+  @Test
+  public void strainNameWithHyphensSurvives() {
+    StrainSegmentId id = StrainSegmentId.parse("X10462-P1C9:AACB03000001:1-50:r");
+    assertEquals("X10462-P1C9", id.getStrain());
+    assertEquals(1, id.getRefStart());
+    assertEquals(50, id.getRefEnd());
+  }
+
+  @Test
+  public void formatRoundTripsBothStrands() {
+    String forward = "A17-48H-7:AACB03000001:5-9:f";
+    String reverse = "A17-48H-7:AACB03000001:5-9:r";
+    assertEquals(forward, StrainSegmentId.parse(forward).format());
+    assertEquals(reverse, StrainSegmentId.parse(reverse).format());
+  }
+
+  // DynSpan's greedy "^(.*):" regex silently mis-parses these. We reject instead.
+  @Test
+  public void rejectsColonInSequenceIdRatherThanMisparsing() {
+    assertRejected("A0003:AAC:B03:100-200:f");
+  }
+
+  @Test
+  public void rejectsMissingStrand() {
+    assertRejected("A0003:AACB03000001:100-200");
+  }
+
+  @Test
+  public void rejectsMissingStrain() {
+    assertRejected("AACB03000001:100-200:f");
+  }
+
+  @Test
+  public void rejectsStartGreaterThanEnd() {
+    assertRejected("A0003:AACB03000001:200-100:f");
+  }
+
+  @Test
+  public void rejectsNonNumericCoordinates() {
+    assertRejected("A0003:AACB03000001:abc-200:f");
+  }
+
+  @Test
+  public void rejectsBadStrandLetter() {
+    assertRejected("A0003:AACB03000001:100-200:x");
+  }
+
+  @Test
+  public void rejectsNull() {
+    assertRejected(null);
+  }
+
+  private static void assertRejected(String sourceId) {
+    try {
+      StrainSegmentId.parse(sourceId);
+      fail("expected IllegalArgumentException for: " + sourceId);
+    }
+    catch (IllegalArgumentException expected) {
+      // expected
+    }
+  }
+}


### PR DESCRIPTION
The Java half of the internal `strain-genomic-segment` record: emits one BED line per segment, in the strain's consensus-sequence coordinates.

Companion PR: **VEuPathDB/ApiCommonModel#209** (record class, search, coordinate-conversion queries, and the `<reporter>` registration that names `BedStrainSegmentReporter` from this PR). Neither works without the other. Design spec and the end-to-end test report live in that PR.

### What's here

- `util/StrainSegmentId.java` — the single parse/format authority for the primary key `<strain>:<refSeq>:<refStart>-<refEnd>:<f|r>`. Validates in the private constructor, so no instance can exist in an invalid state.
- `feature/StrainSegmentFeatureProvider.java` — reads the strain coordinates as attributes and emits the BED fields.
- `BedStrainSegmentReporter.java` — three-line wiring, same shape as `BedDynSpanReporter`.
- Unit tests for both (30 total, passing on cedar).

### The two columns

- **`chrom` is hard-constrained**: it must equal `<strain>_<refSeq>`, the key into the strain consensus FASTA. Read from the `strain_seq_id` attribute so the model stays the source of truth, then **cross-checked** against the key recomputed from the primary key — so a future divergence fails loudly instead of silently naming the wrong contig. Verified byte-exact against real FASTA deflines.
- **`name` is free** — under `deflineFormat=QUERYONLY` seqret emits `'>' + name` verbatim, so it becomes the FASTA defline. Carries provenance; stays bare unless the caller passes `deflineType=full`.

### The rejection this class exists to perform

The attribute query deliberately leaves `strain_start`/`strain_end` unclamped, so a segment inside a deletion reports `strain_end < strain_start`. Nothing upstream rejects it. This provider rejects three conditions, all before `DeflineBuilder`/`BedLine.bed6` sees them, each naming the primary key and the offending values:

1. `strain_end < strain_start` — the deletion inversion;
2. `strain_start < 1` — would emit `chromStart = -1`;
3. `strain_seq_id` disagreeing with the key computed from the PK.

Validation order at the call site is load-bearing and commented as such: neither `DeflineBuilder` nor `bed6` inspects its arguments.

### Running the tests

This module inherits surefire 2.12.4, where **`-Dtest=A+B` matches zero tests and still reports `BUILD SUCCESS`**. Use a comma and read the counts:

```
mvn -Dtest=StrainSegmentIdTest,StrainSegmentFeatureProviderTest -DfailIfNoTests=true test
```

Also: no `wb` target compiles `ApiCommonWebsite/Model`. After editing here run `bld ApiCommonWebsite/Model` before `wb model`, or the model build fails with a misleading `Implementation class for reporter 'bed' … cannot be found`.
