### PR TITLE
Prefix HSSS result IDs with Variant_ instead of NGS_SNP.

### DIFF
--- a/Model/lib/conifer/roles/conifer/vars/ApiCommon/default.yml
+++ b/Model/lib/conifer/roles/conifer/vars/ApiCommon/default.yml
@@ -99,7 +99,7 @@ blastconfig_tempBlastPath: /var/www/Common/tmp/blast
 motifsearchconfig_motifCntxtLen: 20
 
 highspeedsnpsearchconfig_jobsDir: /var/www/Common/tmp/highSpeedSnpSearch
-highspeedsnpsearchconfig_idPrefix: NGS_SNP.
+highspeedsnpsearchconfig_idPrefix: Variant_
 
 highspeedchipsnpsearchconfig_jobsDir: /var/www/Common/tmp/highSpeedChipSnpSearch
 highspeedchipsnpsearchconfig_idPrefix: 'NULL'

--- a/Model/lib/xml/PlasmoDB/news.xml
+++ b/Model/lib/xml/PlasmoDB/news.xml
@@ -32,6 +32,43 @@
 
 
 <record>
+  <attribute name="headline">Corrected statistics in the sample-set SNV search</attribute>
+  <attribute name="date">TBD - set to the release date</attribute>
+  <attribute name="tag"></attribute>
+  <attribute name="category">release</attribute>
+  <attribute name="item">
+    <![CDATA[
+    <div style="margin-left: 3em;">
+      <ul>
+        <li>The <b>SNV Characteristics Within a Group of Samples</b> search (formerly
+        "SNP Characteristics") now reports SNVs per kb of <b>coding</b> sequence. It
+        previously reported all variants per kb of genomic span while labelling the
+        column as CDS. The previous value is still available, in a new
+        "SNVs per kb (gene span)" column.</li>
+
+        <li>Its nonsynonymous/synonymous ratio is now normalized by the number of
+        synonymous and nonsynonymous sites in the gene, derived from the genetic code,
+        and is reported as <b>dN/dS (site-normalized)</b>. The previous raw count ratio
+        carried the genome's codon bias: in <i>P. falciparum</i> the pooled
+        synonymous-site fraction is 17.49% rather than the textbook ~25%. Median dN/dS
+        across the genome moves from about 2.0 to 0.47, which is the expected
+        purifying-selection signature.</li>
+
+        <li><b>Both values change for every gene</b>, and saved strategies that filter on
+        either will return different results than they did before.</li>
+
+        <li>Several result columns were also relabelled to match what they contain:
+        "Nonsynonymous SNPs" is now <b>Missense SNVs</b> (it never included stop-gained
+        variants, which are counted separately), and "Non-coding SNPs" is now
+        <b>Unclassified SNVs</b> (it covers positions where no protein product could be
+        assigned, not only positions outside coding sequence).</li>
+      </ul>
+    </div>
+    ]]>
+  </attribute>
+</record>
+
+<record>
   <attribute name="headline">PlasmoDB 46 Released</attribute>
   <attribute name="date">6 Nov 2019 13:00</attribute>
   <attribute name="tag">PlasmoDB11_19_release</attribute>

--- a/Model/lib/xml/PlasmoDB/news.xml
+++ b/Model/lib/xml/PlasmoDB/news.xml
@@ -32,43 +32,6 @@
 
 
 <record>
-  <attribute name="headline">Corrected statistics in the sample-set SNV search</attribute>
-  <attribute name="date">TBD - set to the release date</attribute>
-  <attribute name="tag"></attribute>
-  <attribute name="category">release</attribute>
-  <attribute name="item">
-    <![CDATA[
-    <div style="margin-left: 3em;">
-      <ul>
-        <li>The <b>SNV Characteristics Within a Group of Samples</b> search (formerly
-        "SNP Characteristics") now reports SNVs per kb of <b>coding</b> sequence. It
-        previously reported all variants per kb of genomic span while labelling the
-        column as CDS. The previous value is still available, in a new
-        "SNVs per kb (gene span)" column.</li>
-
-        <li>Its nonsynonymous/synonymous ratio is now normalized by the number of
-        synonymous and nonsynonymous sites in the gene, derived from the genetic code,
-        and is reported as <b>dN/dS (site-normalized)</b>. The previous raw count ratio
-        carried the genome's codon bias: in <i>P. falciparum</i> the pooled
-        synonymous-site fraction is 17.49% rather than the textbook ~25%. Median dN/dS
-        across the genome moves from about 2.0 to 0.47, which is the expected
-        purifying-selection signature.</li>
-
-        <li><b>Both values change for every gene</b>, and saved strategies that filter on
-        either will return different results than they did before.</li>
-
-        <li>Several result columns were also relabelled to match what they contain:
-        "Nonsynonymous SNPs" is now <b>Missense SNVs</b> (it never included stop-gained
-        variants, which are counted separately), and "Non-coding SNPs" is now
-        <b>Unclassified SNVs</b> (it covers positions where no protein product could be
-        assigned, not only positions outside coding sequence).</li>
-      </ul>
-    </div>
-    ]]>
-  </attribute>
-</record>
-
-<record>
   <attribute name="headline">PlasmoDB 46 Released</attribute>
   <attribute name="date">6 Nov 2019 13:00</attribute>
   <attribute name="tag">PlasmoDB11_19_release</attribute>


### PR DESCRIPTION
Makes the HSSS plugins emit `VariationRecordClass` source_ids, by changing the ApiCommon
cohort default for the result-ID prefix:

```diff
-highspeedsnpsearchconfig_idPrefix: NGS_SNP.
+highspeedsnpsearchconfig_idPrefix: Variant_
```

Paired with the separator fix in `ApiCommonWebService` #20, this produces IDs of the form
`Variant_<sequence>_<location>` — which is what the record class has always actually held,
and what `ApiCommonModel` #212 renames the record to match.

**Merge with `ApiCommonModel` #212 and `ApiCommonWebService` #20.** The prefix, the
separator, and the record-class naming are one change spread across three repos; any two
of the three without the third leaves the HSSS searches emitting IDs the record class
won't resolve.

## Scope of the cohort default

This is an ApiCommon **cohort** default, so it applies to every project in the cohort, not
just PlasmoDB. That is safe because no project has a live `snp` or `chip` search — those
imports are commented out in the shared `apiCommonModel.xml`. The chip default
(`highspeedchipsnpsearchconfig_idPrefix: 'NULL'`) is left alone: that path is equally dead
but out of scope here.

## The release note was pulled from this PR

This PR previously carried a `news.xml` entry for the corrected density and dN/dS
statistics. It has been reverted (`965009fdd` reverts `a039aeee9`) because its `date`
attribute was an unresolvable placeholder — the news page would have rendered `TBD - set
to the release date` literally, and inventing a date was not an option.

The drafted text is preserved in this branch's history and can be recovered with
`git show a039aeee9` when the release date is known. It should return as its own PR at
that point. Nothing about the statistics themselves changed; only the announcement is
deferred.

---

## Related PRs

The variants work spans four repos. **These four merge together** — `ApiCommonModel`'s record rename is a contract the other three depend on by name:

- `ApiCommonModel` VEuPathDB/ApiCommonModel#212 — record rename + precomputed SNV characteristics search
- `ApiCommonWebService` VEuPathDB/ApiCommonWebService#20 — density and dN/dS fixes, test-suite repair
- `ApiCommonWebsite` VEuPathDB/ApiCommonWebsite#310 — HSSS result-ID prefix (`NGS_SNP.` → `Variant_`)
- `web-monorepo` VEuPathDB/web-monorepo#1841 — record-heading override, filename tracking the rename

Coupling worth knowing when sequencing the merges: #1841's customization is resolved by `recordClass.fullName`, so without #212 it matches nothing and the override **silently** stops applying — no error, just the default heading back. #310's prefix and #20's separator together produce the ids #212's record class resolves; any two without the third leaves HSSS emitting ids the record class rejects.

Related but independent, cherry-picked onto `master` — **merge before the four above**:

- `EbrcModelCommon` VEuPathDB/EbrcModelCommon#131 — optional dataset gate for presenter template injection. Not part of the variants work; needed to build a site against a partial appDb.

The release note originally in VEuPathDB/ApiCommonWebsite#310 has been **deferred** (reverted in `965009fdd`) because its `date` attribute was an unresolvable placeholder. Recover the drafted text with `git show a039aeee9` in ApiCommonWebsite and re-PR it once the release date is known.
